### PR TITLE
Not using `;` at the end of the line in example was confusing people

### DIFF
--- a/en/2/11-interactingcontracts2.md
+++ b/en/2/11-interactingcontracts2.md
@@ -126,9 +126,9 @@ We can use it in a contract as follows:
 
 ```
 contract MyContract {
-  address NumberInterfaceAddress = 0xab38... 
+  address NumberInterfaceAddress = 0xab38...; 
   // ^ The address of the FavoriteNumber contract on Ethereum
-  NumberInterface numberContract = NumberInterface(NumberInterfaceAddress)
+  NumberInterface numberContract = NumberInterface(NumberInterfaceAddress);
   // Now `numberContract` is pointing to the other contract
 
   function someFunction() public {

--- a/jp/2/11-interactingcontracts2.md
+++ b/jp/2/11-interactingcontracts2.md
@@ -126,9 +126,9 @@ contract NumberInterface {
 
 ```
 contract MyContract {
-  address NumberInterfaceAddress = 0xab38... 
+  address NumberInterfaceAddress = 0xab38...; 
   // ここは、イーサリアム上のFavoriteNumberコントラクトのアドレスが入る。
-  NumberInterface numberContract = NumberInterface(NumberInterfaceAddress)
+  NumberInterface numberContract = NumberInterface(NumberInterfaceAddress);
   // `numberContract`は他のコントラクトを指し示すものになっているぞ 
 
   function someFunction() public {

--- a/pt/2/11-interactingcontracts2.md
+++ b/pt/2/11-interactingcontracts2.md
@@ -126,10 +126,10 @@ Nós podemos usá-lo em um contrato conforme segue:
 
 ```
 contract MyContract {
-  address NumberInterfaceAddress = 0xab38...
+  address NumberInterfaceAddress = 0xab38...;
   // ^ O endereço do contrato FavoriteNumber no Ethereum
 
-  NumberInterface numberContract = NumberInterface(NumberInterfaceAddress)
+  NumberInterface numberContract = NumberInterface(NumberInterfaceAddress);
   // Agora `numberContract` esta apontando para outro contrato
 
   function someFunction() public {

--- a/zh/2/11-interactingcontracts2.md
+++ b/zh/2/11-interactingcontracts2.md
@@ -126,9 +126,9 @@ contract NumberInterface {
 
 ```
 contract MyContract {
-  address NumberInterfaceAddress = 0xab38... 
+  address NumberInterfaceAddress = 0xab38...; 
   // ^ The address of the FavoriteNumber contract on Ethereum
-  NumberInterface numberContract = NumberInterface(NumberInterfaceAddress)
+  NumberInterface numberContract = NumberInterface(NumberInterfaceAddress);
   // Now `numberContract` is pointing to the other contract
 
   function someFunction() public {


### PR DESCRIPTION
Added `;` at the end of the lines in Lesson 2 Chapter 11, which is due to Solidity syntax.

Here is where semicolon was missing:
![image](https://user-images.githubusercontent.com/6223779/35543253-61c92476-0564-11e8-96de-e62bb0f61a06.png)
