### PR TITLE
correction

### DIFF
--- a/en/5/03-erc721-3.md
+++ b/en/5/03-erc721-3.md
@@ -12,7 +12,7 @@ material:
         import "./zombieattack.sol";
         import "./erc721.sol";
         
-        contract ZombieOwnership is ZombieAttack, ERC721 {
+        contract ZombieOwnership is ZombieBattle, ERC721 {
 
           function balanceOf(address _owner) public view returns (uint256 _balance) {
             // 1. Return the number of zombies `_owner` has here


### PR DESCRIPTION
it says
contract ZombieOwnership is ZombieAttack
it should say
contract ZombieOwnership is ZombieBattle

- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
