### PR TITLE
fix modules in japanese ver. of lesson3 chapter8

### DIFF
--- a/jp/3/08-functionmodifiers.md
+++ b/jp/3/08-functionmodifiers.md
@@ -208,7 +208,7 @@ function driveCar(uint _userId) public olderThan(16, _userId) {
 
 1. `ZombieHelper`で、 `aboveLevel`という`modifier` を作成せよ。また、`_level` (`uint`) と `_zombieId` (`uint`)の2つの引数を取得するように設定せよ。
 
-2. その中で、 `zombies[_zombieId].level`が、`_level`よりも大きいことを確認できるようにせよ。
+2. その中で、 `zombies[_zombieId].level`が、`_level`以上であるを確認できるようにせよ。
 
 3. 修飾子の 最後に`_;`をつけて残りの関数を呼び出すことを忘れるなよ。
 

--- a/jp/3/08-functionmodifiers.md
+++ b/jp/3/08-functionmodifiers.md
@@ -208,7 +208,7 @@ function driveCar(uint _userId) public olderThan(16, _userId) {
 
 1. `ZombieHelper`で、 `aboveLevel`という`modifier` を作成せよ。また、`_level` (`uint`) と `_zombieId` (`uint`)の2つの引数を取得するように設定せよ。
 
-2. その中で、 `zombies[_zombieId].level`が、`_level`以上であるを確認できるようにせよ。
+2. その中で、 `zombies[_zombieId].level`が、`_level`以上であることを確認できるようにせよ。
 
 3. 修飾子の 最後に`_;`をつけて残りの関数を呼び出すことを忘れるなよ。
 


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them  
- [x] I didn't use a machine to do these translations  
- [x] I assign all copyright to Loom Network for these translations  
[In this page](https://cryptozombies.io/jp/lesson/3/chapter/8), I correct the representation `よりも大きい` (only means "greater than"), to `以上である` (means "greater than or equal").