### PR TITLE
Fixed 'Subtracts' typo in Lesson 5 EN

### DIFF
--- a/en/5/09-safemath-1.md
+++ b/en/5/09-safemath-1.md
@@ -305,7 +305,7 @@ material:
           }
 
           /**
-          * @dev Substracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+          * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
           */
           function sub(uint256 a, uint256 b) internal pure returns (uint256) {
             assert(b <= a);

--- a/en/5/10-safemath-2.md
+++ b/en/5/10-safemath-2.md
@@ -310,7 +310,7 @@ material:
           }
 
           /**
-          * @dev Substracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+          * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
           */
           function sub(uint256 a, uint256 b) internal pure returns (uint256) {
             assert(b <= a);

--- a/en/5/11-safemath-3.md
+++ b/en/5/11-safemath-3.md
@@ -313,7 +313,7 @@ material:
           }
 
           /**
-          * @dev Substracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+          * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
           */
           function sub(uint256 a, uint256 b) internal pure returns (uint256) {
             assert(b <= a);

--- a/en/5/12-safemath-4.md
+++ b/en/5/12-safemath-4.md
@@ -313,7 +313,7 @@ material:
           }
 
           /**
-          * @dev Substracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+          * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
           */
           function sub(uint256 a, uint256 b) internal pure returns (uint256) {
             assert(b <= a);

--- a/en/5/13-comments.md
+++ b/en/5/13-comments.md
@@ -309,7 +309,7 @@ material:
           }
 
           /**
-          * @dev Substracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+          * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
           */
           function sub(uint256 a, uint256 b) internal pure returns (uint256) {
             assert(b <= a);


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations

Fixed typo in English version of lesson 5 where in safemath.sol, 'subtracts' was spelled 'substracts' in a comment.
