### PR TITLE
Fix L5 ZombieAttack / ZombieBattle contract references

### DIFF
--- a/en/5/01-erc721-1.md
+++ b/en/5/01-erc721-1.md
@@ -13,7 +13,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/02-erc721-2.md
+++ b/en/5/02-erc721-2.md
@@ -13,7 +13,7 @@ material:
         // Import file here
         
         // Declare ERC721 inheritance here
-        contract ZombieOwnership is ZombieBattle {
+        contract ZombieOwnership is ZombieAttack {
 
         }
       "zombieattack.sol": |
@@ -21,7 +21,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/03-erc721-3.md
+++ b/en/5/03-erc721-3.md
@@ -12,7 +12,7 @@ material:
         import "./zombieattack.sol";
         import "./erc721.sol";
         
-        contract ZombieOwnership is ZombieBattle, ERC721 {
+        contract ZombieOwnership is ZombieAttack, ERC721 {
 
           function balanceOf(address _owner) public view returns (uint256 _balance) {
             // 1. Return the number of zombies `_owner` has here
@@ -39,7 +39,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/04-erc721-4.md
+++ b/en/5/04-erc721-4.md
@@ -100,7 +100,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/05-erc721-5.md
+++ b/en/5/05-erc721-5.md
@@ -12,7 +12,7 @@ material:
         import "./zombieattack.sol";
         import "./erc721.sol";
         
-        contract ZombieOwnership is ZombieBattle, ERC721 {
+        contract ZombieOwnership is ZombieAttack, ERC721 {
 
           function balanceOf(address _owner) public view returns (uint256 _balance) {
             return ownerZombieCount[_owner];
@@ -41,7 +41,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/06-erc721-6.md
+++ b/en/5/06-erc721-6.md
@@ -47,7 +47,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/07-erc721-7.md
+++ b/en/5/07-erc721-7.md
@@ -49,7 +49,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/08-erc721-8.md
+++ b/en/5/08-erc721-8.md
@@ -49,7 +49,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/09-safemath-1.md
+++ b/en/5/09-safemath-1.md
@@ -101,7 +101,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/10-safemath-2.md
+++ b/en/5/10-safemath-2.md
@@ -56,7 +56,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/11-safemath-3.md
+++ b/en/5/11-safemath-3.md
@@ -109,7 +109,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 

--- a/en/5/12-safemath-4.md
+++ b/en/5/12-safemath-4.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 
@@ -345,7 +345,7 @@ material:
 
       import "./zombiehelper.sol";
 
-      contract ZombieBattle is ZombieHelper {
+      contract ZombieAttack is ZombieHelper {
         uint randNonce = 0;
         uint attackVictoryProbability = 70;
 

--- a/en/5/13-comments.md
+++ b/en/5/13-comments.md
@@ -55,7 +55,7 @@ material:
 
         import "./zombiehelper.sol";
 
-        contract ZombieBattle is ZombieHelper {
+        contract ZombieAttack is ZombieHelper {
           uint randNonce = 0;
           uint attackVictoryProbability = 70;
 


### PR DESCRIPTION
`ZombieAttack` and `ZombieBattle` are actually the same contract, answer code and instructions refer to `ZombieAttack`, the file the contract lives in is named `zombieattack.sol`, so `ZombieAttack` should be used everywhere.