### PR TITLE
`head` variable name instead of `i`

### DIFF
--- a/en/6/06.md
+++ b/en/6/06.md
@@ -543,7 +543,7 @@ We did this by splitting up the DNA string into substrings, and having every 2 d
 var head = parseInt(zombie.dna.substring(0, 2)) % 7 + 1
 
 // We have 7 head images with sequential filenames:
-var headSrc = "../assets/zombieparts/head-" + i + ".png"
+var headSrc = "../assets/zombieparts/head-" + head + ".png"
 ```
 
 Each component is positioned with CSS using absolute positioning, to overlay it over the other images.


### PR DESCRIPTION
For some reason `head` variable is referenced as `i` right after it has been declared
