### PR TITLE
Fix a bug in the JP version of lesson 5 chapter 13

### DIFF
--- a/jp/5/13-comments.md
+++ b/jp/5/13-comments.md
@@ -358,8 +358,8 @@ material:
         }
 
         function _transfer(address _from, address _to, uint256 _tokenId) private {
-          ownerZombieCount[_to] = ownerZombieCount[_to].add(1)
-          ownerZombieCount[msg.sender] = ownerZombieCount[msg.sender].sub(1)
+          ownerZombieCount[_to] = ownerZombieCount[_to].add(1);
+          ownerZombieCount[msg.sender] = ownerZombieCount[msg.sender].sub(1);
           zombieToOwner[_tokenId] = _to;
           Transfer(_from, _to, _tokenId);
         }


### PR DESCRIPTION
翻訳の修正ではなくコードのバグです。
答えのコード中の2行の末尾に ; がなく、エディター側のコードには ; があるため、ユーザーはこの ; 2つを削除しないとテストにパス出来ません。