### PR TITLE
Update to include interface keyword

### DIFF
--- a/en/2/10-interactingcontracts.md
+++ b/en/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ Now let's say we had an external contract that wanted to read the data in this c
 First we'd have to define an **_interface_** of the `LuckyNumber` contract:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```
@@ -143,7 +143,7 @@ Notice that this looks like defining a contract, with a few differences. For one
 
 Secondly, we're not defining the function bodies. Instead of curly braces (`{` and `}`), we're simply ending the function declaration with a semi-colon (`;`).
 
-So it kind of looks like a contract skeleton. This is how the compiler knows it's an interface.
+So it kind of looks like a contract skeleton.
 
 By including this interface in our dapp's code our contract knows what the other contract's functions look like, how to call them, and what sort of response to expect.
 


### PR DESCRIPTION
As of [Solidity version 0.4.11](https://github.com/ethereum/solidity/releases/tag/v0.4.11), they introduced the `interface` to replace abstract contracts which are used in this tutorial.

I suggest we update the tutorial to use the `interface` keyword when teaching about [Solidity interfaces](http://solidity.readthedocs.io/en/v0.4.19/contracts.html#interfaces).

- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [ ] I assign all copyright to Loom Network for these translations
