### PR TITLE
Updating to use interface keyword

### DIFF
--- a/en/2/10-interactingcontracts.md
+++ b/en/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ Now let's say we had an external contract that wanted to read the data in this c
 First we'd have to define an **_interface_** of the `LuckyNumber` contract:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/en/2/11-interactingcontracts2.md
+++ b/en/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 Continuing our previous example with `NumberInterface`, once we've defined the interface as:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/en/2/12-multiplereturns.md
+++ b/en/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/en/2/13-kittygenes.md
+++ b/en/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/en/3/01-externaldependencies.md
+++ b/en/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/en/3/02-ownable.md
+++ b/en/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/3/03-onlyowner.md
+++ b/en/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/en/3/04-gas.md
+++ b/en/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/3/05-timeunits.md
+++ b/en/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/3/06-zombiecooldowns.md
+++ b/en/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/en/3/07-zombiecooldowns2.md
+++ b/en/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/en/3/08-functionmodifiers.md
+++ b/en/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/3/09-zombiemodifiers.md
+++ b/en/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/3/10-savinggasview.md
+++ b/en/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/3/11-savinggasstorage.md
+++ b/en/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/3/12-forloops.md
+++ b/en/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/battle-01.md
+++ b/en/4/battle-01.md
@@ -62,7 +62,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/battle-02.md
+++ b/en/4/battle-02.md
@@ -69,7 +69,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/battle-03.md
+++ b/en/4/battle-03.md
@@ -77,7 +77,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/battle-04.md
+++ b/en/4/battle-04.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -222,7 +222,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/en/4/battle-05.md
+++ b/en/4/battle-05.md
@@ -80,7 +80,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/battle-06.md
+++ b/en/4/battle-06.md
@@ -78,7 +78,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/battle-07.md
+++ b/en/4/battle-07.md
@@ -126,7 +126,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/battle-08.md
+++ b/en/4/battle-08.md
@@ -80,7 +80,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/battle-09.md
+++ b/en/4/battle-09.md
@@ -85,7 +85,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/payable.md
+++ b/en/4/payable.md
@@ -50,7 +50,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/4/withdraw.md
+++ b/en/4/withdraw.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/01-erc721-1.md
+++ b/en/5/01-erc721-1.md
@@ -91,7 +91,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/02-erc721-2.md
+++ b/en/5/02-erc721-2.md
@@ -99,7 +99,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/03-erc721-3.md
+++ b/en/5/03-erc721-3.md
@@ -117,7 +117,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/04-erc721-4.md
+++ b/en/5/04-erc721-4.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -276,7 +276,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/en/5/05-erc721-5.md
+++ b/en/5/05-erc721-5.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/06-erc721-6.md
+++ b/en/5/06-erc721-6.md
@@ -125,7 +125,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/07-erc721-7.md
+++ b/en/5/07-erc721-7.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/08-erc721-8.md
+++ b/en/5/08-erc721-8.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/09-safemath-1.md
+++ b/en/5/09-safemath-1.md
@@ -179,7 +179,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/10-safemath-2.md
+++ b/en/5/10-safemath-2.md
@@ -134,7 +134,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/11-safemath-3.md
+++ b/en/5/11-safemath-3.md
@@ -187,7 +187,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/12-safemath-4.md
+++ b/en/5/12-safemath-4.md
@@ -135,7 +135,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/5/13-comments.md
+++ b/en/5/13-comments.md
@@ -133,7 +133,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/6/01.md
+++ b/en/6/01.md
@@ -145,7 +145,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/6/02.md
+++ b/en/6/02.md
@@ -148,7 +148,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/6/03.md
+++ b/en/6/03.md
@@ -617,7 +617,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/6/04.md
+++ b/en/6/04.md
@@ -178,7 +178,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/6/05.md
+++ b/en/6/05.md
@@ -185,7 +185,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/6/06.md
+++ b/en/6/06.md
@@ -198,7 +198,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/6/07.md
+++ b/en/6/07.md
@@ -219,7 +219,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/6/08.md
+++ b/en/6/08.md
@@ -250,7 +250,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/en/6/09.md
+++ b/en/6/09.md
@@ -262,7 +262,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/2/10-interactingcontracts.md
+++ b/es/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ Ahora digamos que tenemos un contrato externo que quiere leer la información de
 Primero debemos usar una **_interfaz_** del contrato `LuckyNumber`:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/es/2/11-interactingcontracts2.md
+++ b/es/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 Continuando con nuestro ejemplo anterior de `NumberInterface`, una vez hemos definido la interfaz como:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/es/2/12-multiplereturns.md
+++ b/es/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/es/2/13-kittygenes.md
+++ b/es/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/es/3/01-externaldependencies.md
+++ b/es/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/es/3/02-ownable.md
+++ b/es/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/3/03-onlyowner.md
+++ b/es/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/es/3/04-gas.md
+++ b/es/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/3/05-timeunits.md
+++ b/es/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/3/06-zombiecooldowns.md
+++ b/es/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/es/3/07-zombiecooldowns2.md
+++ b/es/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/es/3/08-functionmodifiers.md
+++ b/es/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/3/09-zombiemodifiers.md
+++ b/es/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/3/10-savinggasview.md
+++ b/es/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/3/11-savinggasstorage.md
+++ b/es/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/3/12-forloops.md
+++ b/es/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/battle-01.md
+++ b/es/4/battle-01.md
@@ -62,7 +62,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/battle-02.md
+++ b/es/4/battle-02.md
@@ -67,7 +67,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/battle-03.md
+++ b/es/4/battle-03.md
@@ -75,7 +75,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/battle-04.md
+++ b/es/4/battle-04.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -220,7 +220,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/es/4/battle-05.md
+++ b/es/4/battle-05.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/battle-06.md
+++ b/es/4/battle-06.md
@@ -71,7 +71,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/battle-07.md
+++ b/es/4/battle-07.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/battle-08.md
+++ b/es/4/battle-08.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/battle-09.md
+++ b/es/4/battle-09.md
@@ -78,7 +78,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/payable.md
+++ b/es/4/payable.md
@@ -50,7 +50,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/4/withdraw.md
+++ b/es/4/withdraw.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/01-erc721-1.md
+++ b/es/5/01-erc721-1.md
@@ -91,7 +91,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/02-erc721-2.md
+++ b/es/5/02-erc721-2.md
@@ -99,7 +99,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/03-erc721-3.md
+++ b/es/5/03-erc721-3.md
@@ -117,7 +117,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/04-erc721-4.md
+++ b/es/5/04-erc721-4.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -276,7 +276,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/es/5/05-erc721-5.md
+++ b/es/5/05-erc721-5.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/06-erc721-6.md
+++ b/es/5/06-erc721-6.md
@@ -125,7 +125,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/07-erc721-7.md
+++ b/es/5/07-erc721-7.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/08-erc721-8.md
+++ b/es/5/08-erc721-8.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/09-safemath-1.md
+++ b/es/5/09-safemath-1.md
@@ -179,7 +179,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/10-safemath-2.md
+++ b/es/5/10-safemath-2.md
@@ -134,7 +134,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/11-safemath-3.md
+++ b/es/5/11-safemath-3.md
@@ -187,7 +187,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/12-safemath-4.md
+++ b/es/5/12-safemath-4.md
@@ -135,7 +135,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/5/13-comments.md
+++ b/es/5/13-comments.md
@@ -133,7 +133,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/6/01.md
+++ b/es/6/01.md
@@ -117,7 +117,7 @@ material:
       "zombiefeeding.sol": |
         pragma solidity ^0.4.19;
         import "./zombiefactory.sol";
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/6/02.md
+++ b/es/6/02.md
@@ -120,7 +120,7 @@ material:
       "zombiefeeding.sol": |
         pragma solidity ^0.4.19;
         import "./zombiefactory.sol";
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/6/03.md
+++ b/es/6/03.md
@@ -585,7 +585,7 @@ material:
       "zombiefeeding.sol": |
         pragma solidity ^0.4.19;
         import "./zombiefactory.sol";
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/6/04.md
+++ b/es/6/04.md
@@ -142,7 +142,7 @@ material:
       "zombiefeeding.sol": |
         pragma solidity ^0.4.19;
         import "./zombiefactory.sol";
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/6/05.md
+++ b/es/6/05.md
@@ -148,7 +148,7 @@ material:
       "zombiefeeding.sol": |
         pragma solidity ^0.4.19;
         import "./zombiefactory.sol";
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/6/06.md
+++ b/es/6/06.md
@@ -160,7 +160,7 @@ material:
       "zombiefeeding.sol": |
         pragma solidity ^0.4.19;
         import "./zombiefactory.sol";
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/6/07.md
+++ b/es/6/07.md
@@ -180,7 +180,7 @@ material:
       "zombiefeeding.sol": |
         pragma solidity ^0.4.19;
         import "./zombiefactory.sol";
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/6/08.md
+++ b/es/6/08.md
@@ -209,7 +209,7 @@ material:
       "zombiefeeding.sol": |
         pragma solidity ^0.4.19;
         import "./zombiefactory.sol";
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/es/6/09.md
+++ b/es/6/09.md
@@ -220,7 +220,7 @@ material:
       "zombiefeeding.sol": |
         pragma solidity ^0.4.19;
         import "./zombiefactory.sol";
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/2/10-interactingcontracts.md
+++ b/fr/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -133,7 +133,7 @@ Maintenant, imaginons que nous avons un contrat externe qui voudrait lire les do
 Premièrement, nous devrions définir une **_interface_** du contract `LuckyNumber` :
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/fr/2/11-interactingcontracts2.md
+++ b/fr/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 Continuons notre exemple précédent avec `NumberInterface`, une fois que nous avons défini l'interface :
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/fr/2/12-multiplereturns.md
+++ b/fr/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/fr/2/13-kittygenes.md
+++ b/fr/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/fr/3/01-externaldependencies.md
+++ b/fr/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/fr/3/02-ownable.md
+++ b/fr/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/3/03-onlyowner.md
+++ b/fr/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/fr/3/04-gas.md
+++ b/fr/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/3/05-timeunits.md
+++ b/fr/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/3/06-zombiecooldowns.md
+++ b/fr/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/fr/3/07-zombiecooldowns2.md
+++ b/fr/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/fr/3/08-functionmodifiers.md
+++ b/fr/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/3/09-zombiemodifiers.md
+++ b/fr/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/3/10-savinggasview.md
+++ b/fr/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/3/11-savinggasstorage.md
+++ b/fr/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/3/12-forloops.md
+++ b/fr/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/battle-01.md
+++ b/fr/4/battle-01.md
@@ -62,7 +62,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/battle-02.md
+++ b/fr/4/battle-02.md
@@ -67,7 +67,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/battle-03.md
+++ b/fr/4/battle-03.md
@@ -75,7 +75,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/battle-04.md
+++ b/fr/4/battle-04.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -220,7 +220,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/fr/4/battle-05.md
+++ b/fr/4/battle-05.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/battle-06.md
+++ b/fr/4/battle-06.md
@@ -71,7 +71,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/battle-07.md
+++ b/fr/4/battle-07.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/battle-08.md
+++ b/fr/4/battle-08.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/battle-09.md
+++ b/fr/4/battle-09.md
@@ -78,7 +78,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/payable.md
+++ b/fr/4/payable.md
@@ -50,7 +50,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/4/withdraw.md
+++ b/fr/4/withdraw.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/01-erc721-1.md
+++ b/fr/5/01-erc721-1.md
@@ -91,7 +91,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/02-erc721-2.md
+++ b/fr/5/02-erc721-2.md
@@ -99,7 +99,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/03-erc721-3.md
+++ b/fr/5/03-erc721-3.md
@@ -117,7 +117,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/04-erc721-4.md
+++ b/fr/5/04-erc721-4.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -276,7 +276,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/fr/5/05-erc721-5.md
+++ b/fr/5/05-erc721-5.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/06-erc721-6.md
+++ b/fr/5/06-erc721-6.md
@@ -125,7 +125,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/07-erc721-7.md
+++ b/fr/5/07-erc721-7.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/08-erc721-8.md
+++ b/fr/5/08-erc721-8.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/09-safemath-1.md
+++ b/fr/5/09-safemath-1.md
@@ -179,7 +179,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/10-safemath-2.md
+++ b/fr/5/10-safemath-2.md
@@ -134,7 +134,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/11-safemath-3.md
+++ b/fr/5/11-safemath-3.md
@@ -188,7 +188,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/12-safemath-4.md
+++ b/fr/5/12-safemath-4.md
@@ -135,7 +135,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/5/13-comments.md
+++ b/fr/5/13-comments.md
@@ -133,7 +133,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/6/01.md
+++ b/fr/6/01.md
@@ -145,7 +145,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/6/02.md
+++ b/fr/6/02.md
@@ -148,7 +148,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/6/03.md
+++ b/fr/6/03.md
@@ -617,7 +617,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/6/04.md
+++ b/fr/6/04.md
@@ -178,7 +178,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/6/05.md
+++ b/fr/6/05.md
@@ -185,7 +185,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/6/06.md
+++ b/fr/6/06.md
@@ -198,7 +198,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/6/07.md
+++ b/fr/6/07.md
@@ -219,7 +219,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/6/08.md
+++ b/fr/6/08.md
@@ -250,7 +250,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/fr/6/09.md
+++ b/fr/6/09.md
@@ -262,7 +262,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/2/10-interactingcontracts.md
+++ b/jp/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ contract LuckyNumber {
 その場合、まずは`LuckyNumber`コントラクトの**_interface_**を定義するのだ。
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/jp/2/11-interactingcontracts2.md
+++ b/jp/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 前の例を`NumberInterface`を使って、interfaceを次のように定義するぞ：
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/jp/2/12-multiplereturns.md
+++ b/jp/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/jp/2/13-kittygenes.md
+++ b/jp/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/jp/3/01-externaldependencies.md
+++ b/jp/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/jp/3/02-ownable.md
+++ b/jp/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/3/03-onlyowner.md
+++ b/jp/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/jp/3/04-gas.md
+++ b/jp/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/3/05-timeunits.md
+++ b/jp/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/3/06-zombiecooldowns.md
+++ b/jp/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/jp/3/07-zombiecooldowns2.md
+++ b/jp/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/jp/3/08-functionmodifiers.md
+++ b/jp/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/3/09-zombiemodifiers.md
+++ b/jp/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/3/10-savinggasview.md
+++ b/jp/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/3/11-savinggasstorage.md
+++ b/jp/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/3/12-forloops.md
+++ b/jp/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/battle-01.md
+++ b/jp/4/battle-01.md
@@ -62,7 +62,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/battle-02.md
+++ b/jp/4/battle-02.md
@@ -67,7 +67,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/battle-03.md
+++ b/jp/4/battle-03.md
@@ -75,7 +75,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/battle-04.md
+++ b/jp/4/battle-04.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -220,7 +220,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/jp/4/battle-05.md
+++ b/jp/4/battle-05.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/battle-06.md
+++ b/jp/4/battle-06.md
@@ -71,7 +71,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/battle-07.md
+++ b/jp/4/battle-07.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/battle-08.md
+++ b/jp/4/battle-08.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/battle-09.md
+++ b/jp/4/battle-09.md
@@ -78,7 +78,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/payable.md
+++ b/jp/4/payable.md
@@ -50,7 +50,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/4/withdraw.md
+++ b/jp/4/withdraw.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/01-erc721-1.md
+++ b/jp/5/01-erc721-1.md
@@ -91,7 +91,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/02-erc721-2.md
+++ b/jp/5/02-erc721-2.md
@@ -99,7 +99,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/03-erc721-3.md
+++ b/jp/5/03-erc721-3.md
@@ -117,7 +117,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/04-erc721-4.md
+++ b/jp/5/04-erc721-4.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -276,7 +276,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/jp/5/05-erc721-5.md
+++ b/jp/5/05-erc721-5.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/06-erc721-6.md
+++ b/jp/5/06-erc721-6.md
@@ -125,7 +125,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/07-erc721-7.md
+++ b/jp/5/07-erc721-7.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/08-erc721-8.md
+++ b/jp/5/08-erc721-8.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/09-safemath-1.md
+++ b/jp/5/09-safemath-1.md
@@ -179,7 +179,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/10-safemath-2.md
+++ b/jp/5/10-safemath-2.md
@@ -134,7 +134,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/11-safemath-3.md
+++ b/jp/5/11-safemath-3.md
@@ -187,7 +187,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/12-safemath-4.md
+++ b/jp/5/12-safemath-4.md
@@ -135,7 +135,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/5/13-comments.md
+++ b/jp/5/13-comments.md
@@ -133,7 +133,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/6/01.md
+++ b/jp/6/01.md
@@ -145,7 +145,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/6/02.md
+++ b/jp/6/02.md
@@ -148,7 +148,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/6/03.md
+++ b/jp/6/03.md
@@ -617,7 +617,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/6/04.md
+++ b/jp/6/04.md
@@ -178,7 +178,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/6/05.md
+++ b/jp/6/05.md
@@ -185,7 +185,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/6/06.md
+++ b/jp/6/06.md
@@ -198,7 +198,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/6/07.md
+++ b/jp/6/07.md
@@ -219,7 +219,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/6/08.md
+++ b/jp/6/08.md
@@ -250,7 +250,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/jp/6/09.md
+++ b/jp/6/09.md
@@ -262,7 +262,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/2/10-interactingcontracts.md
+++ b/ko/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ contract LuckyNumber {
 먼저, `LuckyNumber` 컨트랙트의 **_인터페이스_**를 정의할 필요가 있네: 
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/ko/2/11-interactingcontracts2.md
+++ b/ko/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 이전 챕터의 예시였던 `NumberInterface`를 활용하여 설명을 이어 나가겠네. 아래와 같이 인터페이스가 정의되면:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/ko/2/12-multiplereturns.md
+++ b/ko/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ko/2/13-kittygenes.md
+++ b/ko/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ko/3/01-externaldependencies.md
+++ b/ko/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ko/3/02-ownable.md
+++ b/ko/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/3/03-onlyowner.md
+++ b/ko/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ko/3/04-gas.md
+++ b/ko/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/3/05-timeunits.md
+++ b/ko/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/3/06-zombiecooldowns.md
+++ b/ko/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ko/3/07-zombiecooldowns2.md
+++ b/ko/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ko/3/08-functionmodifiers.md
+++ b/ko/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/3/09-zombiemodifiers.md
+++ b/ko/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/3/10-savinggasview.md
+++ b/ko/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/3/11-savinggasstorage.md
+++ b/ko/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/3/12-forloops.md
+++ b/ko/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/battle-01.md
+++ b/ko/4/battle-01.md
@@ -62,7 +62,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/battle-02.md
+++ b/ko/4/battle-02.md
@@ -67,7 +67,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/battle-03.md
+++ b/ko/4/battle-03.md
@@ -75,7 +75,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/battle-04.md
+++ b/ko/4/battle-04.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -220,7 +220,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ko/4/battle-05.md
+++ b/ko/4/battle-05.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/battle-06.md
+++ b/ko/4/battle-06.md
@@ -71,7 +71,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/battle-07.md
+++ b/ko/4/battle-07.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/battle-08.md
+++ b/ko/4/battle-08.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/battle-09.md
+++ b/ko/4/battle-09.md
@@ -78,7 +78,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/payable.md
+++ b/ko/4/payable.md
@@ -50,7 +50,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/4/withdraw.md
+++ b/ko/4/withdraw.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/01-erc721-1.md
+++ b/ko/5/01-erc721-1.md
@@ -91,7 +91,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/02-erc721-2.md
+++ b/ko/5/02-erc721-2.md
@@ -99,7 +99,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/03-erc721-3.md
+++ b/ko/5/03-erc721-3.md
@@ -117,7 +117,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/04-erc721-4.md
+++ b/ko/5/04-erc721-4.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -276,7 +276,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ko/5/05-erc721-5.md
+++ b/ko/5/05-erc721-5.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/06-erc721-6.md
+++ b/ko/5/06-erc721-6.md
@@ -125,7 +125,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/07-erc721-7.md
+++ b/ko/5/07-erc721-7.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/08-erc721-8.md
+++ b/ko/5/08-erc721-8.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/09-safemath-1.md
+++ b/ko/5/09-safemath-1.md
@@ -179,7 +179,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/10-safemath-2.md
+++ b/ko/5/10-safemath-2.md
@@ -134,7 +134,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/11-safemath-3.md
+++ b/ko/5/11-safemath-3.md
@@ -187,7 +187,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/12-safemath-4.md
+++ b/ko/5/12-safemath-4.md
@@ -135,7 +135,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ko/5/13-comments.md
+++ b/ko/5/13-comments.md
@@ -133,7 +133,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/no/2/10-interactingcontracts.md
+++ b/no/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ La oss si at vi hadde en ekstern kontrakt som ønsket å lese dataene i denne ko
 Først må vi definere en **_interface_** av `LuckyNumber` kontrakten:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/no/2/11-interactingcontracts2.md
+++ b/no/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 Fortsetter vårt forrige eksempel med `NumberInterface`, når vi har definert interface som:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/no/2/12-multiplereturns.md
+++ b/no/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/no/2/13-kittygenes.md
+++ b/no/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/no/3/01-externaldependencies.md
+++ b/no/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/no/3/02-ownable.md
+++ b/no/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/no/3/03-onlyowner.md
+++ b/no/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/no/3/04-gas.md
+++ b/no/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/no/3/05-timeunits.md
+++ b/no/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/no/3/06-zombiecooldowns.md
+++ b/no/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/no/3/07-zombiecooldowns2.md
+++ b/no/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/no/3/08-functionmodifiers.md
+++ b/no/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/no/3/09-zombiemodifiers.md
+++ b/no/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/no/3/10-savinggasview.md
+++ b/no/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/no/3/11-savinggasstorage.md
+++ b/no/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/no/3/12-forloops.md
+++ b/no/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/2/10-interactingcontracts.md
+++ b/pt/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ Agora digamos que nós temos um contrato externo que quer ler o dado deste contr
 Primeiro nós gostaríamos de definir uma **_interface_** para o contrato `LuckyNumber`:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/pt/2/11-interactingcontracts2.md
+++ b/pt/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 Continuando o nosso próximo exemplo com a `NumberInterface`, uma vez que definimos a interface como:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/pt/2/12-multiplereturns.md
+++ b/pt/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/pt/2/13-kittygenes.md
+++ b/pt/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/pt/3/01-externaldependencies.md
+++ b/pt/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/pt/3/02-ownable.md
+++ b/pt/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/3/03-onlyowner.md
+++ b/pt/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/pt/3/04-gas.md
+++ b/pt/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/3/05-timeunits.md
+++ b/pt/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/3/06-zombiecooldowns.md
+++ b/pt/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/pt/3/07-zombiecooldowns2.md
+++ b/pt/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/pt/3/08-functionmodifiers.md
+++ b/pt/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/3/09-zombiemodifiers.md
+++ b/pt/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/3/10-savinggasview.md
+++ b/pt/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/3/11-savinggasstorage.md
+++ b/pt/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/3/12-forloops.md
+++ b/pt/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/battle-01.md
+++ b/pt/4/battle-01.md
@@ -62,7 +62,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/battle-02.md
+++ b/pt/4/battle-02.md
@@ -67,7 +67,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/battle-03.md
+++ b/pt/4/battle-03.md
@@ -75,7 +75,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/battle-04.md
+++ b/pt/4/battle-04.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -220,7 +220,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/pt/4/battle-05.md
+++ b/pt/4/battle-05.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/battle-06.md
+++ b/pt/4/battle-06.md
@@ -71,7 +71,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/battle-07.md
+++ b/pt/4/battle-07.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/battle-08.md
+++ b/pt/4/battle-08.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/battle-09.md
+++ b/pt/4/battle-09.md
@@ -78,7 +78,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/payable.md
+++ b/pt/4/payable.md
@@ -50,7 +50,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/4/withdraw.md
+++ b/pt/4/withdraw.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/01-erc721-1.md
+++ b/pt/5/01-erc721-1.md
@@ -91,7 +91,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/02-erc721-2.md
+++ b/pt/5/02-erc721-2.md
@@ -99,7 +99,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/03-erc721-3.md
+++ b/pt/5/03-erc721-3.md
@@ -117,7 +117,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/04-erc721-4.md
+++ b/pt/5/04-erc721-4.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -276,7 +276,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/pt/5/05-erc721-5.md
+++ b/pt/5/05-erc721-5.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/06-erc721-6.md
+++ b/pt/5/06-erc721-6.md
@@ -125,7 +125,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/07-erc721-7.md
+++ b/pt/5/07-erc721-7.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/08-erc721-8.md
+++ b/pt/5/08-erc721-8.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/09-safemath-1.md
+++ b/pt/5/09-safemath-1.md
@@ -179,7 +179,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/10-safemath-2.md
+++ b/pt/5/10-safemath-2.md
@@ -134,7 +134,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/11-safemath-3.md
+++ b/pt/5/11-safemath-3.md
@@ -187,7 +187,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/12-safemath-4.md
+++ b/pt/5/12-safemath-4.md
@@ -135,7 +135,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/5/13-comments.md
+++ b/pt/5/13-comments.md
@@ -133,7 +133,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/6/01-intro-web3.md
+++ b/pt/6/01-intro-web3.md
@@ -145,7 +145,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/6/02-web3-providers.md
+++ b/pt/6/02-web3-providers.md
@@ -148,7 +148,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/6/03-talking-to-contracts.md
+++ b/pt/6/03-talking-to-contracts.md
@@ -618,7 +618,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/6/04-calling-contract-functions.md
+++ b/pt/6/04-calling-contract-functions.md
@@ -179,7 +179,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/6/05-metamask-accounts.md
+++ b/pt/6/05-metamask-accounts.md
@@ -186,7 +186,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/6/06-displaying-zombie-army.md
+++ b/pt/6/06-displaying-zombie-army.md
@@ -199,7 +199,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/6/07-sending-transactions.md
+++ b/pt/6/07-sending-transactions.md
@@ -220,7 +220,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/6/08-calling-payable-functions.md
+++ b/pt/6/08-calling-payable-functions.md
@@ -251,7 +251,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/pt/6/09-subscribing-to-events.md
+++ b/pt/6/09-subscribing-to-events.md
@@ -262,7 +262,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/2/10-interactingcontracts.md
+++ b/ru/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ contract LuckyNumber {
 Сначала нам надо будет определить **_интерфейс_** контракта `LuckyNumber` (счастливый номер):
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/ru/2/11-interactingcontracts2.md
+++ b/ru/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 Продолжим наш предыдущий пример с `NumberInterface`, как только зададим интерфейс:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/ru/2/12-multiplereturns.md
+++ b/ru/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ru/2/13-kittygenes.md
+++ b/ru/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ru/3/01-externaldependencies.md
+++ b/ru/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ru/3/02-ownable.md
+++ b/ru/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/3/03-onlyowner.md
+++ b/ru/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ru/3/04-gas.md
+++ b/ru/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/3/05-timeunits.md
+++ b/ru/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/3/06-zombiecooldowns.md
+++ b/ru/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ru/3/07-zombiecooldowns2.md
+++ b/ru/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ru/3/08-functionmodifiers.md
+++ b/ru/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/3/09-zombiemodifiers.md
+++ b/ru/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/3/10-savinggasview.md
+++ b/ru/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/3/11-savinggasstorage.md
+++ b/ru/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/3/12-forloops.md
+++ b/ru/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/battle-01.md
+++ b/ru/4/battle-01.md
@@ -62,7 +62,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/battle-02.md
+++ b/ru/4/battle-02.md
@@ -69,7 +69,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/battle-03.md
+++ b/ru/4/battle-03.md
@@ -77,7 +77,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/battle-04.md
+++ b/ru/4/battle-04.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -220,7 +220,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/ru/4/battle-05.md
+++ b/ru/4/battle-05.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/battle-06.md
+++ b/ru/4/battle-06.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/battle-07.md
+++ b/ru/4/battle-07.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/battle-08.md
+++ b/ru/4/battle-08.md
@@ -75,7 +75,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/battle-09.md
+++ b/ru/4/battle-09.md
@@ -80,7 +80,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/payable.md
+++ b/ru/4/payable.md
@@ -50,7 +50,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/ru/4/withdraw.md
+++ b/ru/4/withdraw.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/2/10-interactingcontracts.md
+++ b/th/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ contract LuckyNumber {
 ก่อนอื่นเลยเราก็ต้อง define **_interface_** ของ contract ที่ชื่อ `LuckyNumber`  ซะก่อน:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/th/2/11-interactingcontracts2.md
+++ b/th/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 มาต่อกันในส่วนของตัวอย่างที่ได้ทำไว้ก่อนหน้า `NumberInterface` หลังจากที่เราได้สร้าง interface หน้าตาดังนี้แล้ว:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/th/2/12-multiplereturns.md
+++ b/th/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/th/2/13-kittygenes.md
+++ b/th/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/th/3/01-externaldependencies.md
+++ b/th/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/th/3/02-ownable.md
+++ b/th/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/3/03-onlyowner.md
+++ b/th/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/th/3/04-gas.md
+++ b/th/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/3/05-timeunits.md
+++ b/th/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/3/06-zombiecooldowns.md
+++ b/th/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/th/3/07-zombiecooldowns2.md
+++ b/th/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/th/3/08-functionmodifiers.md
+++ b/th/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/3/09-zombiemodifiers.md
+++ b/th/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/3/10-savinggasview.md
+++ b/th/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/3/11-savinggasstorage.md
+++ b/th/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/3/12-forloops.md
+++ b/th/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/battle-01.md
+++ b/th/4/battle-01.md
@@ -62,7 +62,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/battle-02.md
+++ b/th/4/battle-02.md
@@ -67,7 +67,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/battle-03.md
+++ b/th/4/battle-03.md
@@ -75,7 +75,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/battle-04.md
+++ b/th/4/battle-04.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -220,7 +220,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/th/4/battle-05.md
+++ b/th/4/battle-05.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/battle-06.md
+++ b/th/4/battle-06.md
@@ -71,7 +71,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/battle-07.md
+++ b/th/4/battle-07.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/battle-08.md
+++ b/th/4/battle-08.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/battle-09.md
+++ b/th/4/battle-09.md
@@ -78,7 +78,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/payable.md
+++ b/th/4/payable.md
@@ -50,7 +50,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/th/4/withdraw.md
+++ b/th/4/withdraw.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/tr/2/10-interactingcontracts.md
+++ b/tr/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -134,7 +134,7 @@ Bu, herhangi birinin şanslı numarasını depolayabileceği basit bir kontrat o
 İlk olarak `LuckyNumber` kontratın bir **_arayüzünü_** tanımlamamız gerekirdi:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/tr/2/11-interactingcontracts2.md
+++ b/tr/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 Önceki örneğimiz `NumberInterface` ile devam ediyor, arayüzü aşu şekilde tanımladığımızda:
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/tr/2/12-multiplereturns.md
+++ b/tr/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/tr/2/13-kittygenes.md
+++ b/tr/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/zh/2/10-interactingcontracts.md
+++ b/zh/2/10-interactingcontracts.md
@@ -67,7 +67,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -136,7 +136,7 @@ contract LuckyNumber {
 
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/zh/2/11-interactingcontracts2.md
+++ b/zh/2/11-interactingcontracts2.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -83,7 +83,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,
@@ -117,7 +117,7 @@ material:
 继续前面 `NumberInterface` 的例子，我们既然将接口定义为：
 
 ```
-contract NumberInterface {
+interface NumberInterface {
   function getNum(address _myAddress) public view returns (uint);
 }
 ```

--- a/zh/2/12-multiplereturns.md
+++ b/zh/2/12-multiplereturns.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -85,7 +85,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/zh/2/13-kittygenes.md
+++ b/zh/2/13-kittygenes.md
@@ -10,7 +10,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -93,7 +93,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/zh/3/01-externaldependencies.md
+++ b/zh/3/01-externaldependencies.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -98,7 +98,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/zh/3/02-ownable.md
+++ b/zh/3/02-ownable.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/3/03-onlyowner.md
+++ b/zh/3/03-onlyowner.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -140,7 +140,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/zh/3/04-gas.md
+++ b/zh/3/04-gas.md
@@ -54,7 +54,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/3/05-timeunits.md
+++ b/zh/3/05-timeunits.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/3/06-zombiecooldowns.md
+++ b/zh/3/06-zombiecooldowns.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -146,7 +146,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/zh/3/07-zombiecooldowns2.md
+++ b/zh/3/07-zombiecooldowns2.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -153,7 +153,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/zh/3/08-functionmodifiers.md
+++ b/zh/3/08-functionmodifiers.md
@@ -21,7 +21,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/3/09-zombiemodifiers.md
+++ b/zh/3/09-zombiemodifiers.md
@@ -26,7 +26,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/3/10-savinggasview.md
+++ b/zh/3/10-savinggasview.md
@@ -37,7 +37,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/3/11-savinggasstorage.md
+++ b/zh/3/11-savinggasstorage.md
@@ -39,7 +39,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/3/12-forloops.md
+++ b/zh/3/12-forloops.md
@@ -41,7 +41,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/battle-01.md
+++ b/zh/4/battle-01.md
@@ -62,7 +62,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/battle-02.md
+++ b/zh/4/battle-02.md
@@ -69,7 +69,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/battle-03.md
+++ b/zh/4/battle-03.md
@@ -77,7 +77,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/battle-04.md
+++ b/zh/4/battle-04.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -223,7 +223,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/zh/4/battle-05.md
+++ b/zh/4/battle-05.md
@@ -78,7 +78,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/battle-06.md
+++ b/zh/4/battle-06.md
@@ -73,7 +73,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/battle-07.md
+++ b/zh/4/battle-07.md
@@ -121,7 +121,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/battle-08.md
+++ b/zh/4/battle-08.md
@@ -75,7 +75,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/battle-09.md
+++ b/zh/4/battle-09.md
@@ -80,7 +80,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/payable.md
+++ b/zh/4/payable.md
@@ -50,7 +50,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/4/withdraw.md
+++ b/zh/4/withdraw.md
@@ -57,7 +57,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/01-erc721-1.md
+++ b/zh/5/01-erc721-1.md
@@ -91,7 +91,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/02-erc721-2.md
+++ b/zh/5/02-erc721-2.md
@@ -99,7 +99,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/03-erc721-3.md
+++ b/zh/5/03-erc721-3.md
@@ -117,7 +117,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/04-erc721-4.md
+++ b/zh/5/04-erc721-4.md
@@ -11,7 +11,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,
@@ -277,7 +277,7 @@ material:
 
       import "./zombiefactory.sol";
 
-      contract KittyInterface {
+      interface KittyInterface {
         function getKitty(uint256 _id) external view returns (
           bool isGestating,
           bool isReady,

--- a/zh/5/05-erc721-5.md
+++ b/zh/5/05-erc721-5.md
@@ -119,7 +119,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/06-erc721-6.md
+++ b/zh/5/06-erc721-6.md
@@ -125,7 +125,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/07-erc721-7.md
+++ b/zh/5/07-erc721-7.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/08-erc721-8.md
+++ b/zh/5/08-erc721-8.md
@@ -127,7 +127,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/09-safemath-1.md
+++ b/zh/5/09-safemath-1.md
@@ -179,7 +179,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/10-safemath-2.md
+++ b/zh/5/10-safemath-2.md
@@ -134,7 +134,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/11-safemath-3.md
+++ b/zh/5/11-safemath-3.md
@@ -187,7 +187,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/12-safemath-4.md
+++ b/zh/5/12-safemath-4.md
@@ -135,7 +135,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/5/13-comments.md
+++ b/zh/5/13-comments.md
@@ -133,7 +133,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/6/01.md
+++ b/zh/6/01.md
@@ -145,7 +145,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/6/02.md
+++ b/zh/6/02.md
@@ -148,7 +148,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/6/03.md
+++ b/zh/6/03.md
@@ -617,7 +617,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/6/04.md
+++ b/zh/6/04.md
@@ -630,7 +630,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/6/05.md
+++ b/zh/6/05.md
@@ -637,7 +637,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/6/06.md
+++ b/zh/6/06.md
@@ -650,7 +650,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/6/07.md
+++ b/zh/6/07.md
@@ -671,7 +671,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/6/08.md
+++ b/zh/6/08.md
@@ -702,7 +702,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,

--- a/zh/6/09.md
+++ b/zh/6/09.md
@@ -714,7 +714,7 @@ material:
 
         import "./zombiefactory.sol";
 
-        contract KittyInterface {
+        interface KittyInterface {
           function getKitty(uint256 _id) external view returns (
             bool isGestating,
             bool isReady,


### PR DESCRIPTION
Searched for all instances of regex "contract \S*Interface", and changed the keyword "contract" to "interface".

Since [Solidity v0.4.11](https://github.com/ethereum/solidity/releases/tag/v0.4.11), they have introduced the interface keyword which should be used when teaching users about [Solidity interfaces](http://solidity.readthedocs.io/en/v0.4.19/contracts.html#interfaces).

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
