### PR TITLE
fix: JP translation lesson1 chapter9

### DIFF
--- a/jp/1/functions2.md
+++ b/jp/1/functions2.md
@@ -66,6 +66,6 @@ function _addToArray(uint _number) private {
 
 # それではテストだ
 
-我々の`createZombie`コントラクトはデフォルトでpublicになっている。つまりだれでもコントラクトから関数を呼び出してゾンビを作れるということだ！これはあってはならないことだから、privateに変えなければならない。
+我々の`createZombie`関数はデフォルトでpublicになっている。つまりだれでもコントラクトから関数を呼び出してゾンビを作れるということだ！これはあってはならないことだから、privateに変えなければならない。
 
 1. private関数になるように、`createZombie`を編集せよ。名付けの通例を忘れるなよ！


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations

'コントラクト' means contruct in English.
Also, '関数' means function in English.

I corrected from 'createZombieコントラクト' to 'createZombie関数'.