### PR TITLE
update `now` description in Time lesson

### DIFF
--- a/en/3/05-timeunits.md
+++ b/en/3/05-timeunits.md
@@ -193,7 +193,7 @@ In order to keep track of how much time a zombie has to wait until it can attack
 
 Solidity provides some native units for dealing with time. 
 
-The variable `now` will return the current unix timestamp (the number of seconds that have passed since January 1st 1970). The unix time as I write this is `1515527488`.
+The variable `now` will return the current unix timestamp of the latest block (the number of seconds that have passed since January 1st 1970). The unix time as I write this is `1515527488`.
 
 >Note: Unix time is traditionally stored in a 32-bit number. This will lead to the "Year 2038" problem, when 32-bit unix timestamps will overflow and break a lot of legacy systems. So if we wanted our DApp to keep running 20 years from now, we could use a 64-bit number instead — but our users would have to spend more gas to use our DApp in the meantime. Design decisions!
 


### PR DESCRIPTION
- [X] I did these translations myself and own copyright for them
- [X] I didn't use a machine to do these translations
- [X] I assign all copyright to Loom Network for these translations

When perusing the solidity docs, I noticed a slight discrepancy between the definition presented in the lesson. From the [docs](https://solidity.readthedocs.io/en/latest/miscellaneous.html#pitfalls):
"`now` (`uint`): current block timestamp (alias for `block.timestamp`)"
