### PR TITLE
Update 08-erc721-8.md require(msg.sender) format

### DIFF
--- a/en/5/08-erc721-8.md
+++ b/en/5/08-erc721-8.md
@@ -314,7 +314,7 @@ material:
         }
 
         function takeOwnership(uint256 _tokenId) public {
-          require(zombieApprovals[_tokenId] == msg.sender);
+          require(msg.sender == zombieApprovals[_tokenId]);
           address owner = ownerOf(_tokenId);
           _transfer(owner, msg.sender, _tokenId);
         }


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations

When require(msg.sender == X) is used in previous lessons, the format is always (msg.sender == X), i.e. the 'msg.sender' is put first. (The order doesn't actually matter, but early in the lessons it is specified to use this format so the primitive answer checker can confirm it.)

In Lesson 5 Chapter 8, this format is reversed in the answer for the takeOwnership function, where the current answer's format is (X == msg.sender). I have reversed this order to match previous lessons. It's a very simple change, but I think it makes a more consistent user experience :)