### PR TITLE
Fix function name in comment

### DIFF
--- a/en/3/07-zombiecooldowns2.md
+++ b/en/3/07-zombiecooldowns2.md
@@ -53,7 +53,7 @@ material:
               newDna = newDna - newDna % 100 + 99;
             }
             _createZombie("NoName", newDna);
-            // 3. Call `triggerCooldown`
+            // 3. Call `_triggerCooldown`
           }
 
           function feedOnKitty(uint _zombieId, uint _kittyId) public {


### PR DESCRIPTION
The function's name is _triggerCooldown yet it is referenced in a comment as triggerCooldown

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
