### PR TITLE
Fix incorrect method name in Chapter 3: onlyOwner Function Modifier

### DIFF
--- a/en/3/03-onlyowner.md
+++ b/en/3/03-onlyowner.md
@@ -314,7 +314,7 @@ contract Ownable {
 }
 ```
 
-Notice the `onlyOwner` modifier on the `likeABoss` function. When you call `likeABoss`, the code inside `onlyOwner` executes **first**. Then when it hits the `_;` statement in `onlyOwner`, it goes back and executes the code inside `likeABoss`.
+Notice the `onlyOwner` modifier on the `renounceOwnership` function. When you call `renounceOwnership`, the code inside `onlyOwner` executes **first**. Then when it hits the `_;` statement in `onlyOwner`, it goes back and executes the code inside `renounceOwnership`.
 
 So while there are other ways you can use modifiers, one of the most common use-cases is to add quick `require` check before a function executes.
 


### PR DESCRIPTION
Replaced unknown method name `likeABoss` with `renounceOwnership`.
The other suitable method name here would be `transferOwnership`

- [X] I did these translations myself and own copyright for them
- [X] I didn't use a machine to do these translations
- [X] I assign all copyright to Loom Network for these translations
