### PR TITLE
mix a function name and mapping name (individualSupply) in Lesson 9

### DIFF
--- a/en/9/06-erc721x.md
+++ b/en/9/06-erc721x.md
@@ -289,7 +289,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than remaining cards");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }
@@ -333,7 +333,7 @@ So our `awardToken` logic should check if this is a Limited Edition card or a St
 
 Continuing our implementation...
 
-1. Create an `if` statement that checks if `individualSupply[_tokenId]` is greater than `0`. If this condition is true, that means this token is a Limited Edition card with a fixed supply.
+1. Create an `if` statement that checks if `individualSupply(_tokenId)` is greater than `0`. If this condition is true, that means this token is a Limited Edition card with a fixed supply.
 
 2. If the `if` statement is true, we want to first make sure the game server has enough of this card left to send to the user and throw an error otherwise. We can check this with the line: `require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than remaining cards");`
 

--- a/en/9/07-erc721x.md
+++ b/en/9/07-erc721x.md
@@ -39,7 +39,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(_from, _tokenId), "Quantity greater than remaining cards");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -299,7 +299,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(_from, _tokenId), "Quantity greater than remaining cards");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/en/9/08-erc721x.md
+++ b/en/9/08-erc721x.md
@@ -41,7 +41,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -305,7 +305,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/en/9/09-erc721x.md
+++ b/en/9/09-erc721x.md
@@ -40,7 +40,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -311,7 +311,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/en/9/10-erc721x.md
+++ b/en/9/10-erc721x.md
@@ -42,7 +42,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -325,7 +325,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/jp/9/06-erc721x.md
+++ b/jp/9/06-erc721x.md
@@ -289,7 +289,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than remaining cards");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/jp/9/07-erc721x.md
+++ b/jp/9/07-erc721x.md
@@ -39,7 +39,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(_from, _tokenId), "Quantity greater than remaining cards");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -299,7 +299,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(_from, _tokenId), "Quantity greater than remaining cards");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/jp/9/08-erc721x.md
+++ b/jp/9/08-erc721x.md
@@ -41,7 +41,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -305,7 +305,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/jp/9/09-erc721x.md
+++ b/jp/9/09-erc721x.md
@@ -40,7 +40,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -311,7 +311,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/jp/9/10-erc721x.md
+++ b/jp/9/10-erc721x.md
@@ -42,7 +42,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -325,7 +325,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/ko/9/06-erc721x.md
+++ b/ko/9/06-erc721x.md
@@ -289,7 +289,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than remaining cards");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/ko/9/07-erc721x.md
+++ b/ko/9/07-erc721x.md
@@ -39,7 +39,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(_from, _tokenId), "Quantity greater than remaining cards");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -299,7 +299,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(_from, _tokenId), "Quantity greater than remaining cards");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/ko/9/08-erc721x.md
+++ b/ko/9/08-erc721x.md
@@ -41,7 +41,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -305,7 +305,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/ko/9/09-erc721x.md
+++ b/ko/9/09-erc721x.md
@@ -40,7 +40,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -311,7 +311,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/ko/9/10-erc721x.md
+++ b/ko/9/10-erc721x.md
@@ -42,7 +42,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
                 require(exists(_tokenId), "TokenID has not been minted");
-                if (individualSupply[_tokenId] > 0) {
+                if (individualSupply(_tokenId) > 0) {
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
                 }
@@ -325,7 +325,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner {
               require(exists(_tokenId), "TokenID has not been minted");
-              if (individualSupply[_tokenId] > 0) {
+              if (individualSupply(_tokenId) > 0) {
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB);
               }

--- a/zh/9/06-erc721x.md
+++ b/zh/9/06-erc721x.md
@@ -289,7 +289,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner { 
               require(exists(_tokenId), "TokenID has not been minted"); 
-              if (individualSupply[_tokenId] > 0) { 
+              if (individualSupply(_tokenId) > 0) { 
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than remaining cards");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB); 
               } 

--- a/zh/9/07-erc721x.md
+++ b/zh/9/07-erc721x.md
@@ -39,7 +39,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner { 
                 require(exists(_tokenId), "TokenID has not been minted"); 
-                if (individualSupply[_tokenId] > 0) { 
+                if (individualSupply(_tokenId) > 0) { 
                     require(_amount <= balanceOf(_from, _tokenId), "Quantity greater than remaining cards");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB); 
                 } 
@@ -299,7 +299,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner { 
               require(exists(_tokenId), "TokenID has not been minted"); 
-              if (individualSupply[_tokenId] > 0) { 
+              if (individualSupply(_tokenId) > 0) { 
                   require(_amount <= balanceOf(_from, _tokenId), "Quantity greater than remaining cards");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB); 
               } 

--- a/zh/9/08-erc721x.md
+++ b/zh/9/08-erc721x.md
@@ -41,7 +41,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner { 
                 require(exists(_tokenId), "TokenID has not been minted"); 
-                if (individualSupply[_tokenId] > 0) { 
+                if (individualSupply(_tokenId) > 0) { 
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB); 
                 } 
@@ -305,7 +305,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner { 
               require(exists(_tokenId), "TokenID has not been minted"); 
-              if (individualSupply[_tokenId] > 0) { 
+              if (individualSupply(_tokenId) > 0) { 
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB); 
               } 

--- a/zh/9/09-erc721x.md
+++ b/zh/9/09-erc721x.md
@@ -40,7 +40,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner { 
                 require(exists(_tokenId), "TokenID has not been minted"); 
-                if (individualSupply[_tokenId] > 0) { 
+                if (individualSupply(_tokenId) > 0) { 
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB); 
                 } 
@@ -311,7 +311,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner { 
               require(exists(_tokenId), "TokenID has not been minted"); 
-              if (individualSupply[_tokenId] > 0) { 
+              if (individualSupply(_tokenId) > 0) { 
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB); 
               } 

--- a/zh/9/10-erc721x.md
+++ b/zh/9/10-erc721x.md
@@ -42,7 +42,7 @@ material:
 
             function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner { 
                 require(exists(_tokenId), "TokenID has not been minted"); 
-                if (individualSupply[_tokenId] > 0) { 
+                if (individualSupply(_tokenId) > 0) { 
                     require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                     _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB); 
                 } 
@@ -325,7 +325,7 @@ material:
 
           function awardToken(uint _tokenId, address _to, uint _amount) public onlyOwner { 
               require(exists(_tokenId), "TokenID has not been minted"); 
-              if (individualSupply[_tokenId] > 0) { 
+              if (individualSupply(_tokenId) > 0) { 
                   require(_amount <= balanceOf(msg.sender, _tokenId), "Quantity greater than from balance");
                   _updateTokenBalance(msg.sender, _tokenId, _amount, ObjectLib.Operations.SUB); 
               } 


### PR DESCRIPTION
In the CryptoZombie Lesson 9, the contract `ZombieCard.sol`, we have declared a `mapping` to store the total supply:

```
mapping(uint => uint) internal tokenIdToIndividualSupply;
```

and a function to view this supply:

```
function individualSupply(uint _tokenId) public view returns (uint);
```

However, in the function `awardToken(uint _tokenId, address _to, uint _amount)`, the second line is:

```
if (individualSupply[_tokenId] > 0)
```

which is wrong. `individualSupply` is the function name not the mapping name. The correct way is:

```
if (individualSupply(_tokenId) > 0)
```




- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [ ] I assign all copyright to Loom Network for these translations
