### PR TITLE
fix solidity version in answer [JP]

### DIFF
--- a/jp/7/03.md
+++ b/jp/7/03.md
@@ -462,7 +462,7 @@ material:
             }
         }
     answer: |
-      pragma solidity 0.4.24;
+      pragma solidity 0.4.25;
 
       import "./ZB/ZBGameMode.sol";
 


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations

in material section, solidity version is declared as `0.4.25`, but in answer it is `0.4.24`.