### PR TITLE
Fix small JP typo

### DIFF
--- a/jp/6/08.md
+++ b/jp/6/08.md
@@ -630,6 +630,6 @@ cryptoZombies.methods.levelUp(zombieId)
 
 3. コントラクトの`levelUp`関数を呼び出すとき、上の例にあるように`"0.001"` Etherを`toWei`に変換して送信しなくてはならない。
 
-4. 成功したら、次のテキストを表示すること: `"Power overwhelming! Zombie successfully leveled up"` (圧倒的なパーだ！ゾンビのレベルアップは成功した！)
+4. 成功したら、次のテキストを表示すること: `"Power overwhelming! Zombie successfully leveled up"` (圧倒的なパワーだ！ゾンビのレベルアップは成功した！)
 
 5. スマートコントラクトを`getZombiesByOwner`でクエリしてUIを表示し直す必要は **ない** — なぜならこの場合変更されたのは一体のゾンビのレベルだけだとわかっているからだ。


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations

Fix small typo. (`Power`:  "パー" -> "パワー")