### PR TITLE
spellcheck hexidecimal -> hexadecimal

### DIFF
--- a/de/1/keccak256.md
+++ b/de/1/keccak256.md
@@ -43,7 +43,7 @@ material:
 ---
 We want our `_generateRandomDna` function to return a (semi) random `uint`. How can we accomplish this?
 
-Ethereum has the hash function `keccak256` built in, which is a version of SHA3. A hash function basically maps an input string into a random 256-bit hexidecimal number. A slight change in the string will cause a large change in the hash.
+Ethereum has the hash function `keccak256` built in, which is a version of SHA3. A hash function basically maps an input string into a random 256-bit hexadecimal number. A slight change in the string will cause a large change in the hash.
 
 It's useful for many purposes in Ethereum, but for right now we're just going to use it for pseudo-random number generation.
 
@@ -77,6 +77,6 @@ In the above, `a * b` returns a `uint`, but we were trying to store it as a `uin
 
 Let's fill in the body of our `_generateRandomDna` function! Here's what it should do:
 
-1. The first line of code should take the `keccak256` hash of `_str` to generate a pseudo-random hexidecimal, typecast it as a `uint`, and finally store the result in a `uint` called `rand`.
+1. The first line of code should take the `keccak256` hash of `_str` to generate a pseudo-random hexadecimal, typecast it as a `uint`, and finally store the result in a `uint` called `rand`.
 
 2. We want our DNA to only be 16 digits long (remember our `dnaModulus`?). So the second line of code should `return` the above value modulus (`%`) `dnaModulus`.

--- a/en/1/keccak256.md
+++ b/en/1/keccak256.md
@@ -58,7 +58,7 @@ material:
 
 We want our `_generateRandomDna` function to return a (semi) random `uint`. How can we accomplish this?
 
-Ethereum has the hash function `keccak256` built in, which is a version of SHA3. A hash function basically maps an input into a random 256-bit hexidecimal number. A slight change in the input will cause a large change in the hash.
+Ethereum has the hash function `keccak256` built in, which is a version of SHA3. A hash function basically maps an input into a random 256-bit hexadecimal number. A slight change in the input will cause a large change in the hash.
 
 It's useful for many purposes in Ethereum, but for right now we're just going to use it for pseudo-random number generation.
 
@@ -97,6 +97,6 @@ In the above, `a * b` returns a `uint`, but we were trying to store it as a `uin
 
 Let's fill in the body of our `_generateRandomDna` function! Here's what it should do:
 
-1. The first line of code should take the `keccak256` hash of `abi.encodePacked(_str)` to generate a pseudo-random hexidecimal, typecast it as a `uint`, and finally store the result in a `uint` called `rand`.
+1. The first line of code should take the `keccak256` hash of `abi.encodePacked(_str)` to generate a pseudo-random hexadecimal, typecast it as a `uint`, and finally store the result in a `uint` called `rand`.
 
 2. We want our DNA to only be 16 digits long (remember our `dnaModulus`?). So the second line of code should `return` the above value modulus (`%`) `dnaModulus`.

--- a/no/1/keccak256.md
+++ b/no/1/keccak256.md
@@ -58,7 +58,7 @@ material:
 
 Vi vil at funksjonen vår `_generateRandomDna` skal returnere en (semi) tilfeldig `uint`. Hvordan kan vi oppnå dette?
 
-Ethereum har hash-funksjonen `keccak256` bygget inn, som er en versjon av SHA3. En hash-funksjon tar en input-string og gjør den om til et 256-bit hexidecimal nummmer. En liten endring i string-en vil gjøre at hele hashen blir endret.
+Ethereum har hash-funksjonen `keccak256` bygget inn, som er en versjon av SHA3. En hash-funksjon tar en input-string og gjør den om til et 256-bit hexadecimal nummmer. En liten endring i string-en vil gjøre at hele hashen blir endret.
 
 Det er nyttig for mange formål i Ethereum, men akkuratt nå kommer vi til å bruke det bare for å lage et pseudo-tilfeldig nummer.
 
@@ -94,6 +94,6 @@ Over, returneres `a * b` som `uint`, men vi prøver å lagre som  `uint8`, noe s
 
 La oss fylle inn funksjonen vår `_generateRandomDna`! Der er det du bør gjøre:
 
-1. Den første linjen med kode bør ta `keccak256` hashen av `_str` for å generere et pseudo-tilfeldig hexidecimal, typecast den som en `uint`, og lagre til slutt resultatet som en `uint` kalt `rand`.
+1. Den første linjen med kode bør ta `keccak256` hashen av `_str` for å generere et pseudo-tilfeldig hexadecimal, typecast den som en `uint`, og lagre til slutt resultatet som en `uint` kalt `rand`.
 
 2. Vi vil at DNA-et vårt skal være 16 sifre langt (husker du `dnaModulus`-en vår?). Så andre linje med kode burde `return`-e verdien returnert over i  modulus (`%`) `dnaModulus`.


### PR DESCRIPTION
Hi, thanks for creating and maintaining these tutorials! This PR corrects a spelling error. hexidecimal should be hexadecimal.

