### PR TITLE
Fix typos in lesson 6

### DIFF
--- a/en/12/06.md
+++ b/en/12/06.md
@@ -25,11 +25,11 @@ We can query the sequence number to see if it's been sent to the validators, bec
 We can do it in two ways: query the state of your accounts or query just the sequence number for a particular account:
 
 ```
->libra& account list
+>libra% account list
 ```
 
 ```
->libra& query sequence  0
+>libra% query sequence  0
 ```
 
 We can use this command to see what the sequence number is. If a transaction goes through the sequence number should increase by 1.
@@ -40,7 +40,7 @@ If the sequence number has gone up, does it mean we succeeded? No, because the t
 
 Let's look at the VISA network, which has a host of participants, including the payment processors and a network of banks. Transactions can be disputed at any step and thus require days to fully process. And sometimes transactions will be disputed days, if not months after the fact.
 
-Finality is not always instant on a blockchain. Older networks tend to use *Probalistic finality* which means that with each block created, the probability of changing the past decreases because it's much much harder. This is why depositing Bitcoins or Ethereum often requires waiting 10, 20, 50 blocks (depending on how much risk the receiver is willing to accept). Newer networks like Libra or our own Basechain have instant finality because they're the result of a vote.
+Finality is not always instant on a blockchain. Older networks tend to use *Probabilistic finality* which means that with each block created, the probability of changing the past decreases because it's much much harder. This is why depositing Bitcoins or Ethereum often requires waiting 10, 20, 50 blocks (depending on how much risk the receiver is willing to accept). Newer networks like Libra or our own Basechain have instant finality because they're the result of a vote.
 
 # Put it to the test
 


### PR DESCRIPTION
Fix typos in lesson 6:

- `Probalistic finality` -> `Probabilistic finality`
- `libra&` -> `libra%`

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
