### PR TITLE
Update 04.md

### DIFF
--- a/en/10/04.md
+++ b/en/10/04.md
@@ -6,7 +6,7 @@ material:
   editor:
     language: JavaScript
     startingCode:
-      "./contracts/2_crypto_zombies.js": |
+      "./migrations/2_crypto_zombies.js": |
         var Migrations = artifacts.require("./Migrations.sol");
         module.exports = function(deployer) {
           deployer.deploy(Migrations);
@@ -30,7 +30,7 @@ Migrations are JavaScript files that help **Truffle** deploy the code to **_Ethe
 
 ## Creating a New Migration
 
-We'll start from the file `truffle init` already created for us- `./contracts/1_initial_migration.js`.
+We'll start from the file `truffle init` already created for us- `./migrations/1_initial_migration.js`.
 Let's take a look at what's inside:
 
 ```javascript
@@ -46,11 +46,11 @@ First, the script tells **Truffle** that we'd want to interact with the `Migrati
 
 Next, it exports a function that accepts an object called `deployer` as a parameter. This object acts as an interface between you (the developer) and **Truffle**'s deployment engine. Even though the `deployer` provides a multitude of useful functions, we won't be using them in the scope of this lesson. Once you've finished, feel free to check out **Truffle**'s <a href="https://truffleframework.com/docs/truffle/getting-started/running-migrations" target=”_blank”>documentation</a> if you're inclined to learn more about **Truffle**'s abilities.
 
-To get everything ready for deployment, we've gone ahead and created a new file `./contracts/2_crypto_zombies.js`, and copied and pasted the content from `./contracts/1_initial_migration.js`.
+To get everything ready for deployment, we've gone ahead and created a new file `./migrations/2_crypto_zombies.js`, and copied and pasted the content from `./migrations/1_initial_migration.js`.
 
 # Put it to the test:
 
-1. Modify `./contracts/2_crypto_zombies.js` to this:
+1. Modify `./migrations/2_crypto_zombies.js` to this:
 
 ```JavaScript
 var CryptoZombies = artifacts.require("./CryptoZombies.sol");


### PR DESCRIPTION
Update paths to migration files where it was write with '/contracts' instead of '/migrations'

- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [ ] I assign all copyright to Loom Network for these translations
