### PR TITLE
Correcting the exercise

### DIFF
--- a/en/1/events.md
+++ b/en/1/events.md
@@ -103,7 +103,7 @@ YourContract.IntegersAdded(function(error, result) {
 
 We want an event to let our front-end know every time a new zombie was created, so the app can display it.
 
-1. Declare an `event` called `NewZombie`. It should pass `zombieId` (a `uint`), `name` (a `string`), and `dna` (a `uint`).
+1. Declare an `event` called `NewZombie`. It should pass `id` (a `uint`), `name` (a `string`), and `dna` (a `uint`).
 
 2. Modify the `_createZombie` function to fire the `NewZombie` event after adding the new Zombie to our `zombies` array. 
 


### PR DESCRIPTION
The step 3 and the code review script have their variable assigned as id, but the step 1 asks you to create a wrong variable name. Easy fix so we don't have to change the rest of the code.

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
