### PR TITLE
Fix: remove one line of code from previous lesson

### DIFF
--- a/en/10/10.md
+++ b/en/10/10.md
@@ -130,7 +130,6 @@ basechain: {
     const chainId = 'default';
     const writeUrl = 'http://basechain.dappchains.com/rpc';
     const readUrl = 'http://basechain.dappchains.com/query';
-    return new LoomTruffleProvider(chainId, writeUrl, readUrl, privateKey);
     const privateKeyPath = path.join(__dirname, 'mainnet_private_key');
     const loomTruffleProvider = getLoomProviderWithPrivateKey(privateKeyPath, chainId, writeUrl, readUrl);
     return loomTruffleProvider;
@@ -186,7 +185,6 @@ module.exports = {
         const chainId = 'default';
         const writeUrl = 'http://basechain.dappchains.com/rpc';
         const readUrl = 'http://basechain.dappchains.com/query';
-        return new LoomTruffleProvider(chainId, writeUrl, readUrl, privateKey);
         const privateKeyPath = path.join(__dirname, 'mainnet_private_key');
         const loomTruffleProvider = getLoomProviderWithPrivateKey(privateKeyPath, chainId, writeUrl, readUrl);
         return loomTruffleProvider;


### PR DESCRIPTION
**Summary**
For Lesson 10 (Deploying Dapps with Truffle) Chapter 10 (Deploy to Basechain) (en), there was one line of code dangling from a previous chapter. 

No new translations. 
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
