### PR TITLE
Update 10.md

### DIFF
--- a/en/11/10.md
+++ b/en/11/10.md
@@ -35,7 +35,7 @@ material:
                     })
                 })
                 xcontext("with the two-step transfer scenario", async () => {
-                    it("should approve and then transfer a zombie when the approved address calls transferForm", async () => {
+                    it("should approve and then transfer a zombie when the approved address calls transferFrom", async () => {
                         const result = await contractInstance.createRandomZombie(zombieNames[0], {from: alice});
                         const zombieId = result.logs[0].args.zombieId.toNumber();
                         // start here
@@ -43,7 +43,7 @@ material:
                         const newOwner = await contractInstance.ownerOf(zombieId);
                         assert.equal(newOwner,bob);
                     })
-                    it("should approve and then transfer a zombie when the owner calls transferForm", async () => {
+                    it("should approve and then transfer a zombie when the owner calls transferFrom", async () => {
                         // TODO: Test the two-step scenario.  The owner calls transferFrom
                      })
                 })
@@ -97,7 +97,7 @@ material:
                 })
             })
             context("with the two-step transfer scenario", async () => {
-                it("should approve and then transfer a zombie when the approved address calls transferForm", async () => {
+                it("should approve and then transfer a zombie when the approved address calls transferFrom", async () => {
                     const result = await contractInstance.createRandomZombie(zombieNames[0], {from: alice});
                     const zombieId = result.logs[0].args.zombieId.toNumber();
                     await contractInstance.approve(bob, zombieId, {from: alice});
@@ -105,7 +105,7 @@ material:
                     const newOwner = await contractInstance.ownerOf(zombieId);
                     assert.equal(newOwner,bob);
                 })
-                xit("should approve and then transfer a zombie when the owner calls transferForm", async () => {
+                xit("should approve and then transfer a zombie when the owner calls transferFrom", async () => {
                     // TODO: Test the two-step scenario.  The owner calls transferFrom
                  })
             })
@@ -153,8 +153,8 @@ Contract: CryptoZombies
     with the single-step transfer scenario
       ✓ should transfer a zombie (334ms)
     with the two-step transfer scenario
-      ✓ should approve and then transfer a zombie when the owner calls transferForm (360ms)
-      - should approve and then transfer a zombie when the approved address calls transferForm
+      ✓ should approve and then transfer a zombie when the owner calls transferFrom (360ms)
+      - should approve and then transfer a zombie when the approved address calls transferFrom
 
 
   4 passing (2s)


### PR DESCRIPTION
fix spelling of `tranferFrom`

- [x ] I did these translations myself and own copyright for them
- [ x] I didn't use a machine to do these translations
- [ x] I assign all copyright to Loom Network for these translations
