### PR TITLE
fixing absent var in for loop of line 662 of en/6/06.md

### DIFF
--- a/en/6/06.md
+++ b/en/6/06.md
@@ -659,6 +659,6 @@ We created an empty `displayZombies` function for you. Let's fill it in.
 
 1. The first thing we'll want to do is empty the `#zombies` div. In JQuery, you can do this with `$("#zombies").empty();`.
 
-2. Next, we'll want to loop through all the ids, using a for loop: `for (id of ids) {`
+2. Next, we'll want to loop through all the ids, using a for loop: `for (var id of ids) {}`
 
 3. Inside the for loop, copy/paste the code block above that called `getZombieDetails(id)` for each id and then used `$("#zombies").append(...)` to add it to our HTML.


### PR DESCRIPTION
- [ √] I did these translations myself and own copyright for them
- [ √] I didn't use a machine to do these translations
- [ √] I assign all copyright to Loom Network for these translations

absent 'var' inside of for loop for line 662 of en/6/06.md. Loop will still run but is not lexically scoped. May teach newcomers the wrong syntax. Added closing "}" brace as well
