### PR TITLE
Fix a typo in chapter 5, lesson 16

### DIFF
--- a/en/16/05.md
+++ b/en/16/05.md
@@ -121,6 +121,6 @@ We've gone ahead and created a function named `removeOracle`, and filled in the 
 3. Inside the `removeOracle` function, add the `require` statement that checks that `numOracles > 1`. Set the message to `"Do not remove the last oracle!"`
 4. Call the `oracle.remove` function, passing it `_oracle` as an argument.
 5. Use `--` to decrement `numOracles`.
-6. Lastly, let's fire `AddOracleEvent`. It takes one argument- `_oracle`.
+6. Lastly, let's fire `RemoveOracleEvent`. It takes one argument- `_oracle`.
 
 This was a lot. And still, there's one thing left. The `addOracle` function should increment the `numOracles` variable. Don't worry about this though, we've gone ahead and added that line of code🤓.


### PR DESCRIPTION
At **Advanced Solidity Path: Get In-depth Knowledge - How to Build an Oracle - Part 3 - Chapter 5: Removing an Oracle** 
Localized by the url [https://cryptozombies.io/en/lesson/16/chapter/5](https://cryptozombies.io/en/lesson/16/chapter/5) .

The item 6 in "Put It to the Test" section, the event name should be ~~`AddOracleEvent`~~ `RemoveOracleEvent`

- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [ ] I assign all copyright to Loom Network for these translations
