### PR TITLE
Update instruction to fire RemoveOracleEvent instead of AddOracleEvent

### DIFF
--- a/en/16/05.md
+++ b/en/16/05.md
@@ -121,6 +121,6 @@ We've gone ahead and created a function named `removeOracle`, and filled in the 
 3. Inside the `removeOracle` function, add the `require` statement that checks that `numOracles > 1`. Set the message to `"Do not remove the last oracle!"`
 4. Call the `oracle.remove` function, passing it `_oracle` as an argument.
 5. Use `--` to decrement `numOracles`.
-6. Lastly, let's fire `AddOracleEvent`. It takes one argument- `_oracle`.
+6. Lastly, let's fire `RemoveOracleEvent`. It takes one argument- `_oracle`.
 
 This was a lot. And still, there's one thing left. The `addOracle` function should increment the `numOracles` variable. Don't worry about this though, we've gone ahead and added that line of code🤓.

--- a/en/16/lessoncomplete.md
+++ b/en/16/lessoncomplete.md
@@ -5,7 +5,7 @@ material:
   lessonComplete: 1
 ---
 
-Congratulations! You've just finsihed implementing your decentralized oracle!
+Congratulations! You've just finished implementing your decentralized oracle!
 
 The lessons in this series were aimed at getting you familiarized with the concepts and the challenges behind writing an oracle. Even if this was just a demo implementation, and we've made a few decisions that simplified things a bit, we trust you have the skills to make a production-ready oracle!💪🏻
 


### PR DESCRIPTION
- [ ] I did these translations myself and own copyright for them (N.A. as no translation involved in this PR)
- [ ] I didn't use a machine to do these translations (N.A. as no translation involved in this PR)
- [x] I assign all copyright to Loom Network for these translations

Current (Instruction in Lesson 16, Chapter 5 states to fire AddOracleEvent instead of RemoveOracleEvent):
![Capture](https://user-images.githubusercontent.com/44690660/110235204-baf76080-7f69-11eb-8b4e-fba33215de0d.PNG)

Changes:
[x] Fix typos