### PR TITLE
fix typo

### DIFF
--- a/en/16/05.md
+++ b/en/16/05.md
@@ -119,7 +119,7 @@ We've gone ahead and created a function named `removeOracle`, and filled in the 
 1. Create a `uint` variable named `numOracles` and initialize it with `0`. Make it `private`.
 2. Declare an event called `RemoveOracleEvent`. It takes one parameter called `oracleAddress` of type `address`.
 3. Inside the `removeOracle` function, add the `require` statement that checks that `numOracles > 1`. Set the message to `"Do not remove the last oracle!"`
-4. Call the `oracle.remove` function, passing it `_oracle` as an argument.
+4. Call the `oracles.remove` function, passing it `_oracle` as an argument.
 5. Use `--` to decrement `numOracles`.
 6. Lastly, let's fire `RemoveOracleEvent`. It takes one argument- `_oracle`.
 

--- a/en/16/06.md
+++ b/en/16/06.md
@@ -166,7 +166,7 @@ To accomplish this, you're going to use a `mapping` that'll associate each reque
 
 ## Put It to the Test
 
-We've gone ahead and removed the `onlyOwner` modifier from the `setLatestEthPrice` function definition, and added a `require` statement that makes sure `oracles.has` `msg.sender)` (once again, please excuse the grammar!). We've also added the line of code that defines the `requestIdToResponse` mapping. Make sure you browse through the code before moving on.
+We've gone ahead and removed the `onlyOwner` modifier from the `setLatestEthPrice` function definition, and added a `require` statement that makes sure `oracles.has` `(msg.sender)` (once again, please excuse the grammar!). We've also added the line of code that defines the `requestIdToResponse` mapping. Make sure you browse through the code before moving on.
 
 1. Let's start by defining a `struct` named `Response` with the following properties inside of it: `oracleAddress` (an `address`), `callerAddress` (an `address`), and `ethPrice` (a `uint256`).
 2. Now let's move to the `setLatestEthPrice`. Declare a `Response` variable called `resp`. It should be stored in `memory`.


### PR DESCRIPTION
should use oracles instead of oracle and missing parenthesis

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
