### PR TITLE
[easy] Fix typo `CallerContracInterface` -> `CallerContractInterface` in en/14/11.md

### DIFF
--- a/en/14/11.md
+++ b/en/14/11.md
@@ -69,7 +69,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |
@@ -92,8 +92,8 @@ material:
         function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
           require(pendingRequests[_id], "This request is not in my pending list.");
           delete pendingRequests[_id];
-          CallerContracInterface callerContractInstance;
-          callerContractInstance = CallerContracInterface(_callerAddress);
+          CallerContractInterface callerContractInstance;
+          callerContractInstance = CallerContractInterface(_callerAddress);
           callerContractInstance.callback(_ethPrice, _id);
           emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
         }
@@ -112,7 +112,7 @@ The `setLatestEthPrice` function is almost finished. Next, you'll have to:
 
 ## Put It to the Test
 
-1. Let's create a `CallerContracInterface` named `callerContractInstance`.
+1. Let's create a `CallerContractInterface` named `callerContractInstance`.
 2. Initialize `callerContractInstance` with the address of the caller contract, just like we did with `myContractInstance` above. Note that the address of the caller contract should come from the function parameters.
 3. Run the `callerContractInstance.callback` function, passing it `_ethPrice` and `_id`.
 4. Lastly, `emit` the `SetLatestEthPriceEvent`. It takes two parameters: `_ethPrice` and `_callerAddress`.


### PR DESCRIPTION
Fixes issue #466

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations