### PR TITLE
Update lesson 6 - 07.md (Fixed/Correctly describe Thai language)

### DIFF
--- a/th/6/07.md
+++ b/th/6/07.md
@@ -527,7 +527,7 @@ material:
 
             window.addEventListener('load', function() {
 
-              // ตรวจสอบว่าbrowser ได้เพิ่ม Web3 เข้ามาแล้วหรือยัง (Mist/MetaMask)
+              // ตรวจสอบว่า browser ได้เพิ่ม Web3 เข้ามาแล้วหรือยัง (Mist/MetaMask)
               if (typeof web3 !== 'undefined') {
                 // ใช้ Mist/MetaMask's provider
                 web3js = new Web3(web3.currentProvider);
@@ -596,10 +596,10 @@ function createRandomZombie(name) {
 }
 ```
 
-ฟังก์ชั่นของเราส่ง หรือ `send` transaction ไปยัง Web3 provider แล้วพ่วง ำvent listener เข้ามาด้วยดังนี้:
+ฟังก์ชั่นของเราส่ง หรือ `send` transaction ไปยัง Web3 provider แล้วพ่วง event listener เข้ามาด้วยดังนี้:
 
 - `receipt` จะออกมาเมื่อ transaction ถูกรับเข้ามาใน block ของ Ethereum ซึ่งแปลว่าซอมบี้ของเราได้ถูกสร้างขึ้นมาและเก็บลงใน contract เป็นที่เรียบร้อย
-- `error` จะ fire ออกมาถ้ามีปัญหาใดๆ ก็ตามที่ขัดขวางการ transaction จากการถูกเก็บลงใน block ยกตัวอย่างเช่น ผู้ใช้ไม่ได้ให้ gas ใรปริมาณที่ได้ถูกกำหนดไว้ แปลว่าเราต้องบอกผู้ใช้ใน UI ว่า transaction จะไม่สำเร็จเพื่อที่พวกเขาจะได้ลองใหม่อีกครั้ง
+- `error` จะ fire ออกมาถ้ามีปัญหาใดๆ ก็ตามที่ขัดขวางการ transaction จากการถูกเก็บลงใน block ยกตัวอย่างเช่น ผู้ใช้ไม่ได้ให้ gas ในปริมาณที่ได้ถูกกำหนดไว้ แปลว่าเราต้องบอกผู้ใช้ใน UI ว่า transaction จะไม่สำเร็จเพื่อที่พวกเขาจะได้ลองใหม่อีกครั้ง
 
 > Note: เรายังสามารถเพิ่ม `gas` และ `gasPrice` ได้ตามใจเมื่อเรียก `send` ขึ้นมา ยกตัวอย่างเช่น `.send({ from: userAccount, gas: 3000000 })` ซึ่งถ้าเราไม่ได้กำหนดตรงส่วนนี้ MetaMask จะให้ผู้ใช้เป็นคนเลือกเอง
 


### PR DESCRIPTION
- Fixed Thai typos at line 599 (ำvent > event)
- Correctly describe Thai language at line 602 (ใรปริมาณ > ในปริมาณ)

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations