### PR TITLE
Update helper to actually work as explained

### DIFF
--- a/en/11/07.md
+++ b/en/11/07.md
@@ -28,14 +28,12 @@ material:
         "test/helpers/utils.js": |
             async function shouldThrow(promise) {
               try {
-                  await promise;
-                 assert(true);
+                 await promise;
+                 assert(false, "The contract did not throw.");
               }
               catch (err) {
                   return;
               }
-            assert(false, "The contract did not throw.");
-
             }
 
             module.exports = {
@@ -77,12 +75,11 @@ In this chapter, we're going to fill in the body of our second test. Here's what
 try {
     //try to create the second zombie
     await contractInstance.createRandomZombie(zombieNames[1], {from: alice});
-    assert(true);
+    assert(false, "The contract did not throw.");
   }
   catch (err) {
     return;
   }
-assert(false, "The contract did not throw.");
 ```
 Now we've got exactly what we wanted, right?
 

--- a/en/11/08.md
+++ b/en/11/08.md
@@ -32,13 +32,11 @@ material:
             async function shouldThrow(promise) {
             try {
                 await promise;
-                assert(true);
+                assert(false, "The contract did not throw.");
             }
             catch (err) {
                 return;
             }
-            assert(false, "The contract did not throw.");
-
             }
 
             module.exports = {

--- a/en/11/09.md
+++ b/en/11/09.md
@@ -43,13 +43,11 @@ material:
             async function shouldThrow(promise) {
             try {
                 await promise;
-                assert(true);
+                assert(false, "The contract did not throw.");
             }
             catch (err) {
                 return;
             }
-            assert(false, "The contract did not throw.");
-
             }
 
             module.exports = {

--- a/en/11/10.md
+++ b/en/11/10.md
@@ -52,13 +52,11 @@ material:
             async function shouldThrow(promise) {
             try {
                 await promise;
-                assert(true);
+                assert(false, "The contract did not throw.");
             }
             catch (err) {
                 return;
             }
-            assert(false, "The contract did not throw.");
-
             }
 
             module.exports = {

--- a/en/11/11.md
+++ b/en/11/11.md
@@ -52,13 +52,11 @@ material:
             async function shouldThrow(promise) {
             try {
                 await promise;
-                assert(true);
+                assert(false, "The contract did not throw.");
             }
             catch (err) {
                 return;
             }
-            assert(false, "The contract did not throw.");
-
             }
 
             module.exports = {

--- a/en/11/12.md
+++ b/en/11/12.md
@@ -68,13 +68,11 @@ material:
             async function shouldThrow(promise) {
             try {
                 await promise;
-                assert(true);
+                assert(false, "The contract did not throw.");
             }
             catch (err) {
                 return;
             }
-            assert(false, "The contract did not throw.");
-
             }
 
             module.exports = {

--- a/en/11/13.md
+++ b/en/11/13.md
@@ -75,13 +75,11 @@ material:
             async function shouldThrow(promise) {
             try {
                 await promise;
-                assert(true);
+                assert(false, "The contract did not throw.");
             }
             catch (err) {
                 return;
             }
-            assert(false, "The contract did not throw.");
-
             }
 
             module.exports = {


### PR DESCRIPTION
In lesson 11 chapter 7 to the end of chapter 7, a utility is shown to help with asserting if calling a function throws an error
```
async function shouldThrow(promise) {
  try {
      await promise;
     assert(true);
  }
  catch (err) {
      return;
  }
assert(false, "The contract did not throw.");

}
```

This works, but I think we can refactor it and remove the assert(true) since it doesn't do anything for us. So I modified it to
```
  async function shouldThrow(promise) {
  try {
      await promise;
      assert(false, "The contract did not throw.");
  }
  catch (err) {
      return;
  }
  }
```



- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
