### PR TITLE
Fix typo "CallerContracInterface"

### DIFF
--- a/en/14/09.md
+++ b/en/14/09.md
@@ -63,7 +63,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/14/10.md
+++ b/en/14/10.md
@@ -49,7 +49,7 @@ material:
             }
             function callback(uint256 _ethPrice, uint256 _id) public onlyOracle {
               require(myRequests[_id], "This request is not in my pending list.");
-              ethPrice = _ethPrice; 
+              ethPrice = _ethPrice;
               delete myRequests[_id];
               emit PriceUpdatedEvent(_ethPrice, _id);
             }
@@ -65,7 +65,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/14/11.md
+++ b/en/14/11.md
@@ -69,7 +69,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |
@@ -92,8 +92,8 @@ material:
         function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
           require(pendingRequests[_id], "This request is not in my pending list.");
           delete pendingRequests[_id];
-          CallerContracInterface callerContractInstance;
-          callerContractInstance = CallerContracInterface(_callerAddress);
+          CallerContractInterface callerContractInstance;
+          callerContractInstance = CallerContractInterface(_callerAddress);
           callerContractInstance.callback(_ethPrice, _id);
           emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
         }
@@ -112,7 +112,7 @@ The `setLatestEthPrice` function is almost finished. Next, you'll have to:
 
 ## Put It to the Test
 
-1. Let's create a `CallerContracInterface` named `callerContractInstance`.
+1. Let's create a `CallerContractInterface` named `callerContractInstance`.
 2. Initialize `callerContractInstance` with the address of the caller contract, just like we did with `myContractInstance` above. Note that the address of the caller contract should come from the function parameters.
 3. Run the `callerContractInstance.callback` function, passing it `_ethPrice` and `_id`.
 4. Lastly, `emit` the `SetLatestEthPriceEvent`. It takes two parameters: `_ethPrice` and `_callerAddress`.

--- a/en/15/01.md
+++ b/en/15/01.md
@@ -71,8 +71,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -118,7 +118,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/15/02.md
+++ b/en/15/02.md
@@ -77,8 +77,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -124,7 +124,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/15/03.md
+++ b/en/15/03.md
@@ -92,8 +92,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -139,7 +139,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/15/04.md
+++ b/en/15/04.md
@@ -98,8 +98,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -145,7 +145,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/15/05.md
+++ b/en/15/05.md
@@ -103,8 +103,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -150,7 +150,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/15/06.md
+++ b/en/15/06.md
@@ -107,8 +107,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -154,7 +154,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/15/07.md
+++ b/en/15/07.md
@@ -115,8 +115,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -162,7 +162,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/15/08.md
+++ b/en/15/08.md
@@ -97,7 +97,7 @@ material:
         module.exports = {
           loadAccount,
         };
- 
+
       "oracle/EthPriceOracle.sol": |
         pragma solidity 0.5.0;
         import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
@@ -118,8 +118,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -130,7 +130,7 @@ material:
         import "./EthPriceOracleInterface.sol";
         import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
         contract CallerContract is Ownable {
-          uint256 private ethPrice; 
+          uint256 private ethPrice;
           EthPriceOracleInterface private oracleInstance;
           address private oracleAddress;
           mapping(uint256=>bool) myRequests;
@@ -165,7 +165,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |
@@ -213,7 +213,7 @@ material:
             processedRequests++
           }
         }
-        
+
         async function processRequest (oracleContract, ownerAddress, id, callerAddress) {
           let retries = 0
           while (retries < MAX_RETRIES) {

--- a/en/15/09.md
+++ b/en/15/09.md
@@ -124,7 +124,7 @@ material:
         module.exports = {
           loadAccount,
         };
- 
+
       "oracle/EthPriceOracle.sol": |
         pragma solidity 0.5.0;
         import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
@@ -145,8 +145,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -157,7 +157,7 @@ material:
         import "./EthPriceOracleInterface.sol";
         import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
         contract CallerContract is Ownable {
-          uint256 private ethPrice; 
+          uint256 private ethPrice;
           EthPriceOracleInterface private oracleInstance;
           address private oracleAddress;
           mapping(uint256=>bool) myRequests;
@@ -192,7 +192,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |
@@ -251,7 +251,7 @@ material:
             processedRequests++
           }
         }
-        
+
         async function processRequest (oracleContract, ownerAddress, id, callerAddress) {
           let retries = 0
           while (retries < MAX_RETRIES) {
@@ -294,7 +294,7 @@ Luckily, there's a small library called `BN.js` that'll help you overcome these 
 
 > ☞ For the above reasons, it's recommended that you always use `BN.js` when dealing with numbers.
 
-Now, the Binance API returns something like `169.87000000`. 
+Now, the Binance API returns something like `169.87000000`.
 
 Let's see how you can convert this to `BN`.
 

--- a/en/15/10.md
+++ b/en/15/10.md
@@ -150,8 +150,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -197,7 +197,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/15/11.md
+++ b/en/15/11.md
@@ -165,8 +165,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -212,7 +212,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/15/12.md
+++ b/en/15/12.md
@@ -187,7 +187,7 @@ material:
         module.exports = {
           loadAccount,
         };
- 
+
       "oracle/EthPriceOracle.sol": |
         pragma solidity 0.5.0;
         import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
@@ -208,8 +208,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -220,7 +220,7 @@ material:
         import "./EthPriceOracleInterface.sol";
         import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
         contract CallerContract is Ownable {
-          uint256 private ethPrice; 
+          uint256 private ethPrice;
           EthPriceOracleInterface private oracleInstance;
           address private oracleAddress;
           mapping(uint256=>bool) myRequests;
@@ -255,7 +255,7 @@ material:
         }
       "oracle/CallerContractInterface.sol": |
         pragma solidity 0.5.0;
-        contract CallerContracInterface {
+        contract CallerContractInterface {
           function callback(uint256 _ethPrice, uint256 id) public;
         }
     answer: |

--- a/en/16/01.md
+++ b/en/16/01.md
@@ -28,8 +28,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -57,8 +57,8 @@ material:
         function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
           require(pendingRequests[_id], "This request is not in my pending list.");
           delete pendingRequests[_id];
-          CallerContracInterface callerContractInstance;
-          callerContractInstance = CallerContracInterface(_callerAddress);
+          CallerContractInterface callerContractInstance;
+          callerContractInstance = CallerContractInterface(_callerAddress);
           callerContractInstance.callback(_ethPrice, _id);
           emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
         }

--- a/en/16/02.md
+++ b/en/16/02.md
@@ -30,8 +30,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -62,8 +62,8 @@ material:
         function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
           require(pendingRequests[_id], "This request is not in my pending list.");
           delete pendingRequests[_id];
-          CallerContracInterface callerContractInstance;
-          callerContractInstance = CallerContracInterface(_callerAddress);
+          CallerContractInterface callerContractInstance;
+          callerContractInstance = CallerContractInterface(_callerAddress);
           callerContractInstance.callback(_ethPrice, _id);
           emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
         }

--- a/en/16/03.md
+++ b/en/16/03.md
@@ -34,8 +34,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -70,8 +70,8 @@ material:
         function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
           require(pendingRequests[_id], "This request is not in my pending list.");
           delete pendingRequests[_id];
-          CallerContracInterface callerContractInstance;
-          callerContractInstance = CallerContracInterface(_callerAddress);
+          CallerContractInterface callerContractInstance;
+          callerContractInstance = CallerContractInterface(_callerAddress);
           callerContractInstance.callback(_ethPrice, _id);
           emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
         }

--- a/en/16/04.md
+++ b/en/16/04.md
@@ -37,8 +37,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -77,8 +77,8 @@ material:
         function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
           require(pendingRequests[_id], "This request is not in my pending list.");
           delete pendingRequests[_id];
-          CallerContracInterface callerContractInstance;
-          callerContractInstance = CallerContracInterface(_callerAddress);
+          CallerContractInterface callerContractInstance;
+          callerContractInstance = CallerContractInterface(_callerAddress);
           callerContractInstance.callback(_ethPrice, _id);
           emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
         }

--- a/en/16/05.md
+++ b/en/16/05.md
@@ -47,8 +47,8 @@ material:
           function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
             require(pendingRequests[_id], "This request is not in my pending list.");
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -98,8 +98,8 @@ material:
         function setLatestEthPrice(uint256 _ethPrice, address _callerAddress, uint256 _id) public onlyOwner {
           require(pendingRequests[_id], "This request is not in my pending list.");
           delete pendingRequests[_id];
-          CallerContracInterface callerContractInstance;
-          callerContractInstance = CallerContracInterface(_callerAddress);
+          CallerContractInterface callerContractInstance;
+          callerContractInstance = CallerContractInterface(_callerAddress);
           callerContractInstance.callback(_ethPrice, _id);
           emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
         }

--- a/en/16/06.md
+++ b/en/16/06.md
@@ -54,8 +54,8 @@ material:
             require(pendingRequests[_id], "This request is not in my pending list.");
             // 2. Continue here
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -114,8 +114,8 @@ material:
           resp = Response(msg.sender, _callerAddress, _ethPrice);
           requestIdToResponse[_id].push(resp);
           delete pendingRequests[_id];
-          CallerContracInterface callerContractInstance;
-          callerContractInstance = CallerContracInterface(_callerAddress);
+          CallerContractInterface callerContractInstance;
+          callerContractInstance = CallerContractInterface(_callerAddress);
           callerContractInstance.callback(_ethPrice, _id);
           emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
         }

--- a/en/16/07.md
+++ b/en/16/07.md
@@ -67,8 +67,8 @@ material:
             requestIdToResponse[_id].push(resp);
             // Start here
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -135,8 +135,8 @@ material:
           uint numResponses = requestIdToResponse[_id].length;
           if (numResponses == THRESHOLD) {
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }
@@ -192,7 +192,7 @@ We've gone ahead and defined a variable called `THRESHOLD`, and then fleshed out
   **starts with:**
 
   ```Solidity
-  CallerContracInterface callerContractInstance;
+  CallerContractInterface callerContractInstance;
   ```
 
   **ends with:**

--- a/en/16/08.md
+++ b/en/16/08.md
@@ -69,8 +69,8 @@ material:
             if (numResponses == THRESHOLD) {
               // Start here
               delete pendingRequests[_id];
-              CallerContracInterface callerContractInstance;
-              callerContractInstance = CallerContracInterface(_callerAddress);
+              CallerContractInterface callerContractInstance;
+              callerContractInstance = CallerContractInterface(_callerAddress);
               callerContractInstance.callback(_ethPrice, _id);
               emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
             }
@@ -143,8 +143,8 @@ material:
             }
             computedEthPrice = computedEthPrice / numResponses;
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }

--- a/en/16/09.md
+++ b/en/16/09.md
@@ -75,8 +75,8 @@ material:
               }
               computedEthPrice = computedEthPrice / numResponses; // Replace this with a `SafeMath` method
               delete pendingRequests[_id];
-              CallerContracInterface callerContractInstance;
-              callerContractInstance = CallerContracInterface(_callerAddress);
+              CallerContractInterface callerContractInstance;
+              callerContractInstance = CallerContractInterface(_callerAddress);
               callerContractInstance.callback(_ethPrice, _id);
               emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
             }
@@ -151,8 +151,8 @@ material:
             }
             computedEthPrice = computedEthPrice.div(numResponses);
             delete pendingRequests[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(_ethPrice, _id);
             emit SetLatestEthPriceEvent(_ethPrice, _callerAddress);
           }

--- a/en/16/10.md
+++ b/en/16/10.md
@@ -76,8 +76,8 @@ material:
               computedEthPrice = computedEthPrice.div(numResponses);
               delete pendingRequests[_id];
               // Delete `_id` from `requestIdToResponse`
-              CallerContracInterface callerContractInstance;
-              callerContractInstance = CallerContracInterface(_callerAddress);
+              CallerContractInterface callerContractInstance;
+              callerContractInstance = CallerContractInterface(_callerAddress);
               callerContractInstance.callback(_ethPrice, _id); // Update this line code
               emit SetLatestEthPriceEvent(_ethPrice, _callerAddress); // Update this line of code
             }
@@ -153,8 +153,8 @@ material:
             computedEthPrice = computedEthPrice.div(numResponses);
             delete pendingRequests[_id];
             delete requestIdToResponse[_id];
-            CallerContracInterface callerContractInstance;
-            callerContractInstance = CallerContracInterface(_callerAddress);
+            CallerContractInterface callerContractInstance;
+            callerContractInstance = CallerContractInterface(_callerAddress);
             callerContractInstance.callback(computedEthPrice, _id);
             emit SetLatestEthPriceEvent(computedEthPrice, _callerAddress);
           }


### PR DESCRIPTION
Fixes a small typo in the content and the source examples.

```
CallerContracInterface => CallerContractInterface
```
 
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
