### PR TITLE
aligning variable-name in exercise

### DIFF
--- a/en/14/02.md
+++ b/en/14/02.md
@@ -50,6 +50,6 @@ In the box to the right, we've pasted an empty shell for the caller contract.
 
 2. Next, create a function called `setOracleInstanceAddress`. This function takes an `address` argument named `_oracleInstanceAddress`. It's a `public` function, and it doesn't return anything.
 
-3. The first line of code should set `oracleAddress` to `_address`.
+3. The first line of code should set `oracleAddress` to `_oracleInstanceAddress`.
 
 You'll continue fleshing out this function in the next chapter.

--- a/en/14/10.md
+++ b/en/14/10.md
@@ -104,7 +104,7 @@ First, your function must make sure that only the owner can call this function. 
 
 ## Put It to the Test
 
-1. Create a `public function` named `setLatestEthPrice`. It should take three parameters: `_ethPrice` (a `uint256`), `callerAddress` (an `address`), and `id` (a `uint256`). Don't forget to make it so that only the owner could call it.
+1. Create a `public function` named `setLatestEthPrice`. It should take three parameters: `_ethPrice` (a `uint256`), `_callerAddress` (an `address`), and `_id` (a `uint256`). Don't forget to make it so that only the owner could call it.
 2. Use `require` to check if `pendingRequests[_id]` is `true`. The second parameter should be "This request is not in my pending list.". If you don't know how to do this, revisit Chapter 6 to refresh your memory.
 3. Remove `id` from the `pendingRequests` mapping. In case you're stuck, here's how you can remove a key from a mapping:
 


### PR DESCRIPTION
- [X] I did these translations myself and own copyright for them
- [X] I didn't use a machine to do these translations
- [X] I assign all copyright to Loom Network for these translations

Aligning the variable name passed in the function with what the user is supposed to input.