### PR TITLE
Update en/10/05.md - replace var with const

### DIFF
--- a/en/10/05.md
+++ b/en/10/05.md
@@ -114,13 +114,13 @@ We asked you to install an additional package called `truffle-hdwallet-provider`
 Now, we want to edit our configuration file to use `HDWalletProvider`. To get this to work we'll add a line at the top of the file:
 
 ```JavaScript
-var HDWalletProvider = require("truffle-hdwallet-provider");
+const HDWalletProvider = require("truffle-hdwallet-provider");
 ```
 
 Next, we'll create a new variable to store our mnemonic:
 
 ```JavaScript
-var mnemonic = "onions carrots beans ...";
+const mnemonic = "onions carrots beans ...";
 ```
 
 Note that we don't recommend storing secrets like a mnemonic or a private key in a configuration file.


### PR DESCRIPTION
Replace `var` with `const` - updated syntax and the solutions expects const as well. 

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
