### PR TITLE
Fix off-by-one error in rand logic

### DIFF
--- a/en/4/battle-08.md
+++ b/en/4/battle-08.md
@@ -276,7 +276,7 @@ material:
           Zombie storage myZombie = zombies[_zombieId];
           Zombie storage enemyZombie = zombies[_targetId];
           uint rand = randMod(100);
-          if (rand <= attackVictoryProbability) {
+          if (rand < attackVictoryProbability) {
             myZombie.winCount++;
             myZombie.level++;
             enemyZombie.lossCount++;
@@ -288,11 +288,11 @@ material:
 
 Now that we have a `winCount` and `lossCount`, we can update them depending on which zombie wins the fight.
 
-In chapter 6 we calculated a random number from 0 to 100. Now let's use that number to determine who wins the fight, and update our stats accordingly.
+In chapter 6 we calculated a random number from 0 to 99. Now let's use that number to determine who wins the fight, and update our stats accordingly.
 
 ## Put it to the test
 
-1. Create an `if` statement that checks if `rand` is **_less than or equal to_** `attackVictoryProbability`.
+1. Create an `if` statement that checks if `rand` is **_less than_** `attackVictoryProbability`.
 
 2. If this condition is true, our zombie wins! So:
 


### PR DESCRIPTION
`randMod()` generates integers from 0 to 99 inclusively.
There are 70 numbers between 0 and 69 inclusively and 30 numbers from 70 to 99 inclusively.
The way the previous code was written there would be a 71% chance of a win and a 29% chance of a loss.
To fix this we want to check that `rand` is strictly less than `attackVictoryProbability`.
