### PR TITLE
Change from "less" to "greater"

### DIFF
--- a/en/4/battle-08.md
+++ b/en/4/battle-08.md
@@ -292,7 +292,7 @@ In chapter 6 we calculated a random number from 0 to 100. Now let's use that num
 
 ## Put it to the test
 
-1. Create an `if` statement that checks if `rand` is **_less than or equal to_** `attackVictoryProbability`.
+1. Create an `if` statement that checks if `rand` is **_greater than or equal to_** `attackVictoryProbability`.
 
 2. If this condition is true, our zombie wins! So:
 


### PR DESCRIPTION
I could not wrap it inside my head on why `myZombie` would win if the `rand` value is less than the `attackVictoryProbability`, it didn't really make sense.

The compiler checker too has to be updated and use `>=` instead of `<=`

https://github.com/loomnetwork/cryptozombie-lessons/blob/master/en/4/battle-08.md

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations


