### PR TITLE
fix: remove early return statement

### DIFF
--- a/en/10/10.md
+++ b/en/10/10.md
@@ -130,7 +130,6 @@ basechain: {
     const chainId = 'default';
     const writeUrl = 'http://basechain.dappchains.com/rpc';
     const readUrl = 'http://basechain.dappchains.com/query';
-    return new LoomTruffleProvider(chainId, writeUrl, readUrl, privateKey);
     const privateKeyPath = path.join(__dirname, 'mainnet_private_key');
     const loomTruffleProvider = getLoomProviderWithPrivateKey(privateKeyPath, chainId, writeUrl, readUrl);
     return loomTruffleProvider;
@@ -186,7 +185,6 @@ module.exports = {
         const chainId = 'default';
         const writeUrl = 'http://basechain.dappchains.com/rpc';
         const readUrl = 'http://basechain.dappchains.com/query';
-        return new LoomTruffleProvider(chainId, writeUrl, readUrl, privateKey);
         const privateKeyPath = path.join(__dirname, 'mainnet_private_key');
         const loomTruffleProvider = getLoomProviderWithPrivateKey(privateKeyPath, chainId, writeUrl, readUrl);
         return loomTruffleProvider;

--- a/fa/10/10.md
+++ b/fa/10/10.md
@@ -130,7 +130,6 @@ basechain: {
     const chainId = 'default';
     const writeUrl = 'http://basechain.dappchains.com/rpc';
     const readUrl = 'http://basechain.dappchains.com/query';
-    return new LoomTruffleProvider(chainId, writeUrl, readUrl, privateKey);
     const privateKeyPath = path.join(__dirname, 'mainnet_private_key');
     const loomTruffleProvider = getLoomProviderWithPrivateKey(privateKeyPath, chainId, writeUrl, readUrl);
     return loomTruffleProvider;
@@ -186,7 +185,6 @@ module.exports = {
         const chainId = 'default';
         const writeUrl = 'http://basechain.dappchains.com/rpc';
         const readUrl = 'http://basechain.dappchains.com/query';
-        return new LoomTruffleProvider(chainId, writeUrl, readUrl, privateKey);
         const privateKeyPath = path.join(__dirname, 'mainnet_private_key');
         const loomTruffleProvider = getLoomProviderWithPrivateKey(privateKeyPath, chainId, writeUrl, readUrl);
         return loomTruffleProvider;


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations

Removed an orphan return statement left from previous lessons on creating the Loom provider for Truffle.