### PR TITLE
Fix typo in ko/2/12-multiplereturns.md

### DIFF
--- a/ko/2/12-multiplereturns.md
+++ b/ko/2/12-multiplereturns.md
@@ -157,6 +157,6 @@ function getLastReturnValue() external {
 
   > 참고: `KittyInterface` 인터페이스에서 `genes`은 `uint256`형이지만, 레슨 1에서 배웠던 내용을 되새겨 보면 `uint`는 `uint256`의 다른 표현으로, 서로 동일하지. 
 
-3. 그 다음, 이 함수는 `_kittyID`를 전달하여 `kittyContract.getKitty` 함수를 호출하고 `genes`을 `kittyDna`에 저장해야 한다.`getKitty`가 다수의 변수를 반환한다는 사실을 기억할 것 (정확히 말하자면 10개의 변수를 반환한다). 하지만 우리가 관심 있는 변수는 마지막 변수인 `genes`이다. 쉼표 수를 유심히 세어 보기 바란다! 
+3. 그 다음, 이 함수는 `_kittyId`를 전달하여 `kittyContract.getKitty` 함수를 호출하고 `genes`을 `kittyDna`에 저장해야 한다.`getKitty`가 다수의 변수를 반환한다는 사실을 기억할 것 (정확히 말하자면 10개의 변수를 반환한다). 하지만 우리가 관심 있는 변수는 마지막 변수인 `genes`이다. 쉼표 수를 유심히 세어 보기 바란다! 
 
 4. 마지막으로 이 함수는 `feedAndMultiply`를 호출하고 이 때 `_zombieId`와 `kittyDna`를 전달해야 한다. 


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations

`_kittyID` to `_kittyId` at line 160