### PR TITLE
Remove an extra space in Lesson 5 Chapter 10

### DIFF
--- a/en/5/10-safemath-2.md
+++ b/en/5/10-safemath-2.md
@@ -400,7 +400,7 @@ material:
         }
 
         function transferFrom(address _from, address _to, uint256 _tokenId) external payable {
-          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals [_tokenId] == msg.sender);
+          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals[_tokenId] == msg.sender);
           _transfer(_from, _to, _tokenId);
         }
 

--- a/es/5/10-safemath-2.md
+++ b/es/5/10-safemath-2.md
@@ -399,7 +399,7 @@ material:
         }
 
         function transferFrom(address _from, address _to, uint256 _tokenId) external payable {
-          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals [_tokenId] == msg.sender);
+          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals[_tokenId] == msg.sender);
           _transfer(_from, _to, _tokenId);
         }
 

--- a/fa/5/10-safemath-2.md
+++ b/fa/5/10-safemath-2.md
@@ -400,7 +400,7 @@ material:
         }
 
         function transferFrom(address _from, address _to, uint256 _tokenId) external payable {
-          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals [_tokenId] == msg.sender);
+          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals[_tokenId] == msg.sender);
           _transfer(_from, _to, _tokenId);
         }
 

--- a/it/5/10-safemath-2.md
+++ b/it/5/10-safemath-2.md
@@ -398,7 +398,7 @@ material:
         }
 
         function transferFrom(address _from, address _to, uint256 _tokenId) external payable {
-          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals [_tokenId] == msg.sender);
+          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals[_tokenId] == msg.sender);
           _transfer(_from, _to, _tokenId);
         }
 

--- a/ru/5/10-safemath-2.md
+++ b/ru/5/10-safemath-2.md
@@ -400,7 +400,7 @@ material:
         }
 
         function transferFrom(address _from, address _to, uint256 _tokenId) external payable {
-          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals [_tokenId] == msg.sender);
+          require (zombieToOwner[_tokenId] == msg.sender || zombieApprovals[_tokenId] == msg.sender);
           _transfer(_from, _to, _tokenId);
         }
 


### PR DESCRIPTION
Turned `zombieApprovals [_tokenId]` into `zombieApprovals[_tokenId]` in all translations for Lesson 5 Chapter 10 (SafeMath part 2)

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
