### PR TITLE
Fix typo in ru/3/8-functionmodifiers.md

### DIFF
--- a/ru/3/08-functionmodifiers.md
+++ b/ru/3/08-functionmodifiers.md
@@ -187,7 +187,6 @@ material:
 mapping (uint => uint) public age;
 
 // Модификатор требует, чтобы пользователь был старше определенного возраста:
-Modifier that requires this user to be older than a certain age:
 modifier olderThan(uint _age, uint _userId) {
   require (age[_userId] >= _age);
   _;


### PR DESCRIPTION
Removed English sentence in Russian locale

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
