### PR TITLE
Fix typo in ru/3/12-forloops.md

### DIFF
--- a/ru/3/12-forloops.md
+++ b/ru/3/12-forloops.md
@@ -208,9 +208,9 @@ material:
 
 Очевидная реализация функции `getZombiesByOwner` — хранить карту соответствий `mapping` владельцев зомби-армий в контракте `ZombieFactory`:
 
-`` `
-mapping (address => uint[]) public ownerToZombies
-`` `
+```
+mapping (address => uint[]) public ownerToZombies;
+```
 
 Каждый раз при создании нового зомби просто используем `ownerToZombies[owner].push (zombieId)`, чтобы добавить солдата в массив владельца. И `getZombiesByOwner` будет очень простой функцией:
 


### PR DESCRIPTION
Fixed missed signs 

> ``
>;

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
