### PR TITLE
Change "financial" to "financiera"

### DIFF
--- a/es/2/2-mappings.md
+++ b/es/2/2-mappings.md
@@ -103,7 +103,7 @@ En la Lección 1 vimos los **_structs_** y los **_arrays_**. Los **_mapeos_** so
 Definir un `mapping` se asemejaría a esto:
 
 ```
-// Para una aplicación financial, guardamos un uint con el balance de su cuenta:
+// Para una aplicación financiera, guardamos un uint con el balance de su cuenta:
 mapping (address => uint) public accountBalance;
 // O podría usarse para guardar / ver los usuarios basados en ese userId
 mapping (uint => string) userIdToName;


### PR DESCRIPTION
"financial" is not a spanish adjective, the right one is "financiera"

See https://dle.rae.es/financial and https://dle.rae.es/financiero

- [ ] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
