### PR TITLE
fix typo - remove duplicate function 'transferFrom'

### DIFF
--- a/en/5/05-erc721-5.md
+++ b/en/5/05-erc721-5.md
@@ -350,8 +350,6 @@ and
 
 `function approve(address _approved, uint256 _tokenId) external payable;`
 
-`function transferFrom(address _from, address _to, uint256 _tokenId) external payable;`
-
 1. The first way is the token's owner calls `transferFrom` with his `address` as the `_from` parameter, the `address` he wants to transfer to as the `_to` parameter, and the `_tokenId` of the token he wants to transfer.
 
 2. The second way is the token's owner first calls `approve` with the address he wants to transfer to, and the `_tokenID` . The contract then stores who is approved to take a token, usually in a `mapping (uint256 => address)`. Then, when the owner or the approved address calls `transferFrom`, the contract checks if that `msg.sender` is  the owner or is approved by the owner to take the token, and if so it transfers the token to him.


### PR DESCRIPTION
- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
