### PR TITLE
Suggestion for higher version of solidity

### DIFF
--- a/en/1/events.md
+++ b/en/1/events.md
@@ -56,7 +56,8 @@ material:
           Zombie[] public zombies;
 
           function _createZombie(string memory _name, uint _dna) private {
-              uint id = zombies.push(Zombie(_name, _dna)) - 1;
+              zombies.push(Zombie(_name, _dna));
+              uint id = zombies.length - 1;
               emit NewZombie(id, _name, _dna);
           }
 
@@ -107,4 +108,4 @@ We want an event to let our front-end know every time a new zombie was created, 
 
 2. Modify the `_createZombie` function to fire the `NewZombie` event after adding the new Zombie to our `zombies` array.
 
-3. You're going to need the zombie's `id`. `array.push()` returns a `uint` of the new length of the array - and since the first item in an array has index 0, `array.push() - 1` will be the index of the zombie we just added. Store the result of `zombies.push() - 1` in a `uint` called `id`, so you can use this in the `NewZombie` event in the next line.
+3. You're going to need the zombie's `id`. Since the first item in an array has index 0, you can get zombie's `id` with `zombies.lengh - 1` in a `uint`, so you can use it in the `NewZombie` event in the next line.


### PR DESCRIPTION
Operation push has changed behavior since since solidity 0.6. It no longer returns the length but a reference to the added element.

- [ ] I did these translations myself and own copyright for them
- [ ] I didn't use a machine to do these translations
- [ ] I assign all copyright to Loom Network for these translations
