### PR TITLE
Remove 'js' from 'ethersjs' in help command

### DIFF
--- a/en/17/01.md
+++ b/en/17/01.md
@@ -5,7 +5,7 @@ requireLogin: false
 material:
     terminal:
         help:
-            You should probably run `npm init -y` followed by `npm install ethersjs zksync`😉
+            You should probably run `npm init -y` followed by `npm install ethers zksync`😉
         commands:
             "npm init -y":
                 hint: npm init -y


### PR DESCRIPTION
The answer and hint just use 'ethers' whilst the help said 'ethersjs'

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
