### PR TITLE
update(11/03.md): Fix JS comment to match the reqs

### DIFF
--- a/en/11/03.md
+++ b/en/11/03.md
@@ -10,7 +10,7 @@ material:
                 const CryptoZombies = artifacts.require("CryptoZombies");
                 contract("CryptoZombies", (accounts) => {
                     //1. initialize `alice` and `bob`
-                    it("should be able to create a new zombie", () => { //2 & 3. Replace the first parameter and make the callback async
+                    it("should be able to create a new zombie", () => { //2. Make the callback async
                     })
                 })
 


### PR DESCRIPTION
The comment refers to a third point in the requirements and asks to `"replace the first parameter"`, however there are only two requirement points.

- [x] I did these translations myself and own copyright for them
- [x] I didn't use a machine to do these translations
- [x] I assign all copyright to Loom Network for these translations
