### PR TITLE
English 'syntax' update to help the sentence make more sense.

### DIFF
--- a/en/4/payable.md
+++ b/en/4/payable.md
@@ -287,7 +287,7 @@ In this chapter, we're going to introduce one more function modifier: `payable`.
 
 Let that sink in for a minute. When you call an API function on a normal web server, you can't send US dollars along with your function call — nor can you send Bitcoin.
 
-But in Ethereum, because both the money (_Ether_), the data (*transaction payload*), and the contract code itself all live on Ethereum, it's possible for you to call a function **and** pay money to the contract at the same time.
+But in Ethereum, because the money (_Ether_), the data (*transaction payload*), and the contract code itself all live on Ethereum, it's possible for you to call a function **_and_** pay money to the contract at the same time. 
 
 This allows for some really interesting logic, like requiring a certain payment to the contract in order to execute a function.
 


### PR DESCRIPTION
Removed the word "both" as it implies only 2 arguments or parts, but this sentence has 3: money, data and contract itself. Also added em/italics to "and" in addition to bold text because italics imply an emphasized tone of inflection - felt more appropriate than bold, only.

- [x ] I did these translations myself and own copyright for them
- [x ] I didn't use a machine to do these translations
- [x ] I assign all copyright to Loom Network for these translations
